### PR TITLE
Update deployment to be an OpenShift template

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -1,40 +1,94 @@
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: v1
+kind: Template
 metadata:
-  labels:
-    app: mbop
-  name: mbop
-  namespace: boot
-spec:
-  progressDeadlineSeconds: 600
-  replicas: 1
-  revisionHistoryLimit: 10
-  selector:
-    matchLabels:
+  annotations:
+    description: mBOP mocks the IT BOP service with our own instance providers such as keycloak for user data
+    tags: mbop
+  name: mbop-server
+objects:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
       app: mbop
-  strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
-  template:
-    metadata:
-      creationTimestamp: null
-      labels:
+    name: mbop
+  spec:
+    replicas: ${{REPLICAS}}
+    selector:
+      matchLabels:
         app: mbop
-    spec:
-      containers:
-      - env:
-        - name: KEYCLOAK_SERVER
-          value: http://192.168.x.x:12345
-        image: 127.0.0.1:5000/mbop:1
-        imagePullPolicy: IfNotPresent
-        name: mbop
-        resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-      dnsPolicy: ClusterFirst
-      restartPolicy: Always
-      schedulerName: default-scheduler
-      securityContext: {}
-      terminationGracePeriodSeconds: 30
+    strategy:
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
+    template:
+      metadata:
+        labels:
+          app: mbop
+      spec:
+        containers:
+        - env:
+          - name: KEYCLOAK_SERVER
+            value: "${KEYCLOAK_SCHEME}://${KEYCLOAK_HOST}:${KEYCLOAK_PORT}${KEYCLOAK_PATH}"
+          image: quay.io/cloudservices/mbop:${IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          name: mbop
+          ports:
+          - containerPort: ${{PORT}}
+            name: svc
+            protocol: TCP
+          resources:
+            requests:
+              cpu: ${CPU_REQUEST}
+              memory: ${MEMORY_REQUEST}
+            limits:
+              cpu: ${CPU_LIMIT}
+              memory: ${MEMORY_LIMIT}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: mbop
+    name: mbop
+  spec:
+    ports:
+    - name: svc
+      port: ${{PORT}}
+      protocol: TCP
+      targetPort: ${{PORT}}
+parameters:
+- name: PORT
+  description: Port the application will listen on
+  value: "8090"
+- name: REPLICAS
+  description: The number of replicas to use in the deployment
+  value: '1'
+- name: IMAGE_TAG
+  description: Image tag
+  required: true
+  value: latest
+- name: KEYCLOAK_SCHEME
+  description: keycloak's scheme (http/s)
+  value: http
+- name: KEYCLOAK_HOST
+  description: keycloak's host
+  value: 192.168.x.x
+- name: KEYCLOAK_PORT
+  description: keycloak's port
+  value: "12345"
+- name: KEYCLOAK_PATH
+  description: keycloak's path if behind a reverse proxy
+  value: ""
+- name: MEMORY_LIMIT
+  description: memory limit for mbop pod
+  value: 512Mi
+- name: MEMORY_REQUEST
+  description: memory request for mbop pod
+  value: 128Mi
+- name: CPU_LIMIT
+  description: cpu limit for mbop pod
+  value: "1"
+- name: CPU_REQUEST
+  description: cpu request for mbop pod
+  value: "0.5"


### PR DESCRIPTION
Going through and making this an OCP template - it should spit out a resource basically the same as before by default minus the namespace and default progressDeadlineSeconds. 

cc @psav 