### PR TITLE
Add config package/struct for storing application configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+all: build
+
+build:
+	go build cmd/mbop/mbop.go
+
+clean:
+	rm -f mbop
+	go clean -cache
+
+lint:
+	golangci-lint run --enable=errcheck,gocritic,gofmt,goimports,gosec,gosimple,govet,ineffassign,revive,staticcheck,typecheck,unused,bodyclose --fix=false --max-same-issues=20  --print-issued-lines=true --print-linter-name=true --sort-results=true
+
+fix:
+	golangci-lint run --enable=errcheck,gocritic,gofmt,goimports,gosec,gosimple,govet,ineffassign,revive,staticcheck,typecheck,unused,bodyclose --fix=true --max-same-issues=20  --print-issued-lines=true --print-linter-name=true --sort-results=true
+
+.PHONY: build clean lint fix

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,3 +33,8 @@ func fetchWithDefault(name, defaultValue string) string {
 
 	return defaultValue
 }
+
+// TO BE USED FROM TESTING ONLY.
+func Reset() {
+	conf = nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,35 @@
+package config
+
+import "os"
+
+type mbopConfig struct {
+	MailerModule string
+	JwtModule    string
+	JwkURL       string
+	UsersModule  string
+}
+
+var conf *mbopConfig
+
+func Get() *mbopConfig {
+	if conf != nil {
+		return conf
+	}
+
+	c := &mbopConfig{}
+	c.UsersModule = fetchWithDefault("USERS_MODULE", "")
+	c.JwtModule = fetchWithDefault("JWT_MODULE", "")
+	c.JwkURL = fetchWithDefault("JWK_URL", "")
+	c.MailerModule = fetchWithDefault("MAILER_MODULE", "print")
+
+	conf = c
+	return conf
+}
+
+func fetchWithDefault(name, defaultValue string) string {
+	if v, ok := os.LookupEnv(name); ok {
+		return v
+	}
+
+	return defaultValue
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,21 +2,21 @@ package config
 
 import "os"
 
-type mbopConfig struct {
+type MbopConfig struct {
 	MailerModule string
 	JwtModule    string
 	JwkURL       string
 	UsersModule  string
 }
 
-var conf *mbopConfig
+var conf *MbopConfig
 
-func Get() *mbopConfig {
+func Get() *MbopConfig {
 	if conf != nil {
 		return conf
 	}
 
-	c := &mbopConfig{}
+	c := &MbopConfig{}
 	c.UsersModule = fetchWithDefault("USERS_MODULE", "")
 	c.JwtModule = fetchWithDefault("JWT_MODULE", "")
 	c.JwkURL = fetchWithDefault("JWK_URL", "")

--- a/internal/handlers/constants.go
+++ b/internal/handlers/constants.go
@@ -1,0 +1,7 @@
+package handlers
+
+/*
+Constants used throughout the handlers package, will probably mostly be module definitions
+*/
+
+const awsModule = "aws"

--- a/internal/handlers/jwt_v1_handler.go
+++ b/internal/handlers/jwt_v1_handler.go
@@ -2,9 +2,9 @@ package handlers
 
 import (
 	"encoding/json"
+	"github.com/redhatinsights/mbop/internal/config"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/RedHatInsights/jwk2pem"
@@ -16,17 +16,15 @@ type JWTResp struct {
 }
 
 func JWTV1Handler(w http.ResponseWriter, r *http.Request) {
-	switch os.Getenv("JWT_MODULE") {
-	case "aws":
+	switch config.Get().JwtModule {
+	case awsModule:
 		kid := r.URL.Query().Get("kid")
 		if kid == "" {
 			do400(w, "kid required to return correct pub key")
 			return
 		}
 
-		jwkURL := os.Getenv("JWK_URL")
-		resp, err := http.Get(jwkURL) //nolint
-
+		resp, err := http.Get(config.Get().JwkURL)
 		if err != nil {
 			l.Log.Error(err, "error getting JWKs")
 			do500(w, "error getting JWKs: "+err.Error())

--- a/internal/handlers/jwt_v1_handler.go
+++ b/internal/handlers/jwt_v1_handler.go
@@ -2,10 +2,11 @@ package handlers
 
 import (
 	"encoding/json"
-	"github.com/redhatinsights/mbop/internal/config"
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/redhatinsights/mbop/internal/config"
 
 	"github.com/RedHatInsights/jwk2pem"
 	l "github.com/redhatinsights/mbop/internal/logger"

--- a/internal/handlers/jwt_v1_handler_test.go
+++ b/internal/handlers/jwt_v1_handler_test.go
@@ -3,12 +3,13 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/redhatinsights/mbop/internal/config"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/redhatinsights/mbop/internal/config"
 
 	"github.com/RedHatInsights/jwk2pem"
 	"github.com/stretchr/testify/assert"

--- a/internal/handlers/jwt_v1_handler_test.go
+++ b/internal/handlers/jwt_v1_handler_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/redhatinsights/mbop/internal/config"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -36,6 +37,7 @@ func (suite *TestSuite) TestAwsJWTGetNoKid() {
 		_, _ = w.Write(suite.testData)
 	}))
 	defer suite.mockServer.Close()
+	config.Reset()
 
 	os.Setenv("JWT_MODULE", "aws")
 	os.Setenv("JWK_URL", fmt.Sprintf("%s/v1/jwt", suite.mockServer.URL))
@@ -63,6 +65,7 @@ func (suite *TestSuite) TestAwsJWTGetNoKidMatch() {
 		_, _ = w.Write(suite.testData)
 	}))
 	defer mockServer.Close()
+	config.Reset()
 
 	os.Setenv("JWT_MODULE", "aws")
 	os.Setenv("JWK_URL", fmt.Sprintf("%s/v1/jwt", mockServer.URL))
@@ -91,6 +94,7 @@ func (suite *TestSuite) TestAwsJWTGetKidMatch() {
 		_, _ = w.Write(suite.testData)
 	}))
 	defer mockServer.Close()
+	config.Reset()
 
 	os.Setenv("JWT_MODULE", "aws")
 	os.Setenv("JWK_URL", fmt.Sprintf("%s/v1/jwt", mockServer.URL))

--- a/internal/handlers/status_handler.go
+++ b/internal/handlers/status_handler.go
@@ -1,9 +1,10 @@
 package handlers
 
 import (
+	"net/http"
+
 	"github.com/redhatinsights/mbop/internal/config"
 	"github.com/redhatinsights/mbop/internal/models"
-	"net/http"
 )
 
 func Status(w http.ResponseWriter, r *http.Request) {

--- a/internal/handlers/status_handler.go
+++ b/internal/handlers/status_handler.go
@@ -1,20 +1,19 @@
 package handlers
 
 import (
-	"net/http"
-	"os"
-
+	"github.com/redhatinsights/mbop/internal/config"
 	"github.com/redhatinsights/mbop/internal/models"
+	"net/http"
 )
 
 func Status(w http.ResponseWriter, r *http.Request) {
 	status := models.Status{
 		ConfiguredModules: models.ConfiguredModules{
-			Users:  os.Getenv("USERS_MODULE"),
-			Mailer: os.Getenv("MAILER_MODULE"),
-			JWT:    os.Getenv("JWT_MODULE"),
+			Users:  config.Get().UsersModule,
+			Mailer: config.Get().MailerModule,
+			JWT:    config.Get().JwtModule,
 		},
 	}
 
-	_, _ = w.Write(status.ToJSON())
+	sendJSON(w, status)
 }

--- a/internal/handlers/users_v1_handler.go
+++ b/internal/handlers/users_v1_handler.go
@@ -1,13 +1,13 @@
 package handlers
 
 import (
+	"github.com/redhatinsights/mbop/internal/config"
 	"net/http"
-	"os"
 )
 
 func UsersV1Handler(w http.ResponseWriter, r *http.Request) {
-	switch os.Getenv("USERS_MODULE") {
-	case "aws":
+	switch config.Get().UsersModule {
+	case awsModule:
 		// acctNum := chi.URLParam(r, "accountNumber")
 		// users, err := users.ListUsersV1(acctNum)
 		// ...

--- a/internal/handlers/users_v1_handler.go
+++ b/internal/handlers/users_v1_handler.go
@@ -1,8 +1,9 @@
 package handlers
 
 import (
-	"github.com/redhatinsights/mbop/internal/config"
 	"net/http"
+
+	"github.com/redhatinsights/mbop/internal/config"
 )
 
 func UsersV1Handler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Going ahead with adding a `config/` package for storing app config as we get more and more down the line.

Keeping it simple for now - just a `struct` with various fields and a helper function to fetch from the environment with defaults. Maybe we want to add the ability to return errors eventually - but thats another discussion if there are ever "should we panic" configuration(s).

---

- First commit adds the config package
- Second commit updates some areas to use the config values as an example

cc @coderbydesign @aleccohan