### PR TITLE
Fix odd-number-of-args panic on startup err

### DIFF
--- a/cmd/mbop/mbop.go
+++ b/cmd/mbop/mbop.go
@@ -35,6 +35,6 @@ func main() {
 
 	l.Log.Info("Starting MBOP Server on :8090")
 	if err := srv.ListenAndServe(); err != nil {
-		l.Log.Error(err, "reason", "server couldn't start")
+		l.Log.Error(err, "server couldn't start")
 	}
 }


### PR DESCRIPTION
Fixes #12

It looks like the error just comes from needing k/v pairs in logging - and we "only" had one extra after the message. This logr interface is interesting.

---

Error message now:
```
2023-02-08T10:32:22.344-0600    ERROR   mbop/mbop.go:38 server couldn't start   {"error": "listen tcp :8090: bind: address already in use"}
```
