### PR TITLE
Add `/v1/registrations` handler

### DIFF
--- a/cmd/mbop/mbop.go
+++ b/cmd/mbop/mbop.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/redhatinsights/platform-go-middlewares/identity"
-
 	"github.com/redhatinsights/mbop/internal/service/mailer"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 

--- a/cmd/mbop/mbop.go
+++ b/cmd/mbop/mbop.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+
 	"github.com/redhatinsights/mbop/internal/service/mailer"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 
@@ -39,8 +41,8 @@ func main() {
 	r.Post("/v1/sendEmails", handlers.SendEmails)
 	r.Get("/v3/accounts/{orgID}/users", handlers.AccountsV3UsersHandler)
 	r.Post("/v3/accounts/{orgID}/usersBy", handlers.AccountsV3UsersByHandler)
+	r.With(identity.EnforceIdentity).Post("/v1/registrations", handlers.RegistrationHandler)
 	r.With(identity.EnforceIdentity).Get("/v1/registrations/token", handlers.TokenHandler)
-	r.Post("/v1/registrations", handlers.RegistrationHandler)
 
 	err := mailer.InitConfig()
 	if err != nil {

--- a/cmd/mbop/mbop.go
+++ b/cmd/mbop/mbop.go
@@ -40,6 +40,7 @@ func main() {
 	r.Get("/v3/accounts/{orgID}/users", handlers.AccountsV3UsersHandler)
 	r.Post("/v3/accounts/{orgID}/usersBy", handlers.AccountsV3UsersByHandler)
 	r.With(identity.EnforceIdentity).Get("/v1/registrations/token", handlers.TokenHandler)
+	r.Post("/v1/registrations", handlers.RegistrationHandler)
 
 	err := mailer.InitConfig()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,12 @@ require (
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/go-logr/logr v1.2.2
 	github.com/go-logr/zapr v1.2.3
+	github.com/golang-jwt/jwt/v5 v5.0.0-rc.1
 	github.com/golang-migrate/migrate/v4 v4.15.2
+	github.com/google/uuid v1.3.0
 	github.com/openshift-online/ocm-sdk-go v0.1.311
 	github.com/pkg/errors v0.9.1
+	github.com/redhatinsights/platform-go-middlewares v0.20.1-0.20230119152702-e3779317d1aa
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/zap v1.21.0
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1
@@ -37,10 +40,8 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
 	github.com/goccy/go-json v0.10.0 // indirect
 	github.com/golang-jwt/jwt/v4 v4.4.1 // indirect
-	github.com/golang-jwt/jwt/v5 v5.0.0-rc.1 // indirect
 	github.com/golang/glog v1.0.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
@@ -70,7 +71,6 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
-	github.com/redhatinsights/platform-go-middlewares v0.20.1-0.20230119152702-e3779317d1aa // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,6 @@ require (
 	golang.org/x/sys v0.4.0 // indirect
 	golang.org/x/text v0.6.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/protobuf v1.28.0 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1862,8 +1862,8 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
-google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -445,6 +445,7 @@ github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoD
 github.com/form3tech-oss/jwt-go v3.2.5+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsouza/fake-gcs-server v1.17.0/go.mod h1:D1rTE4YCyHFNa99oyJJ5HyclvN/0uQR+pM/VdlL83bw=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
@@ -958,6 +959,7 @@ github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/
 github.com/neo4j/neo4j-go-driver v1.8.1-0.20200803113522-b626aa943eba/go.mod h1:ncO5VaFWh0Nrt+4KT4mOZboaczBZcLuHrG+/sUeP8gI=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
@@ -1885,6 +1887,7 @@ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -44,6 +44,7 @@ func do404(w http.ResponseWriter, msg string) {
 }
 
 func doError(w http.ResponseWriter, msg string, code int) {
+	l.Log.Info("Error during request", "error", msg, "status", code)
 	sendJSONWithStatusCode(w, newResponse(msg), code)
 }
 

--- a/internal/handlers/jwt_v1_handler_test.go
+++ b/internal/handlers/jwt_v1_handler_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/redhatinsights/mbop/internal/config"
+	"github.com/redhatinsights/mbop/internal/logger"
 
 	"github.com/RedHatInsights/jwk2pem"
 	"github.com/stretchr/testify/assert"
@@ -25,6 +26,7 @@ type TestSuite struct {
 }
 
 func (suite *TestSuite) SetupSuite() {
+	_ = logger.Init()
 	suite.testData, _ = os.ReadFile("testdata/jwks.json")
 	suite.testDataStruct = &jwk2pem.JWKeys{}
 	err := json.Unmarshal([]byte(suite.testData), suite.testDataStruct)

--- a/internal/handlers/registration_handler.go
+++ b/internal/handlers/registration_handler.go
@@ -1,0 +1,89 @@
+package handlers
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/redhatinsights/mbop/internal/store"
+)
+
+type registationCreateRequest struct {
+	Uid *string `json:"uid,omitempty"`
+}
+
+type registrationCreateResponse struct {
+	Registered string `json:"registered,omitempty"`
+	OrgID      string `json:"org_id,omitempty"`
+	UID        string `json:"uid,omitempty"`
+}
+
+func RegistrationHandler(w http.ResponseWriter, r *http.Request) {
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		do500(w, "failed to read body bytes: "+err.Error())
+		return
+	}
+
+	var body registationCreateRequest
+	err = json.Unmarshal(b, &body)
+	if err != nil {
+		do400(w, "failed to unmarshal body: "+err.Error())
+		return
+	}
+
+	if body.Uid == nil || *body.Uid == "" {
+		do400(w, "required parameter [uid] not found in body")
+		return
+	}
+
+	raw := r.Header.Get("Authorization")
+	if raw == "" {
+		do400(w, "need bearer token for registration")
+		return
+	}
+
+	if !strings.HasPrefix(raw, "Bearer ") {
+		do400(w, "need bearer token for registration")
+		return
+	}
+
+	parts := strings.Fields(raw)
+	if len(parts) != 2 {
+		do400(w, "bearer token in improper format")
+		return
+	}
+
+	db := store.GetStore()
+
+	// TODO: look up orgid from token?
+	token := parts[1]
+	orgId := _getOrgIdFromToken(token)
+
+	_, err = db.Find(orgId, *body.Uid)
+	if err == nil {
+		doError(w, "existing registration found", 409)
+		return
+	}
+
+	id, err := db.Create(&store.Registration{
+		OrgID: orgId,
+		UID:   *body.Uid,
+	})
+	if err != nil {
+		do500(w, "failed to create registration: "+err.Error())
+		return
+	}
+
+	sendJSONWithStatusCode(w, &registrationCreateResponse{
+		Registered: id,
+		OrgID:      orgId,
+		UID:        *body.Uid,
+	}, 201)
+}
+
+// TODO: call out to AMS
+func _getOrgIdFromToken(token string) string {
+	return token
+}

--- a/internal/handlers/registration_handler_test.go
+++ b/internal/handlers/registration_handler_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/redhatinsights/mbop/internal/config"
 	"github.com/redhatinsights/mbop/internal/store"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -27,8 +29,13 @@ func (suite *RegistrationTestSuite) BeforeTest(_, _ string) {
 	suite.rec = httptest.NewRecorder()
 	suite.Nil(store.SetupStore())
 
+	// creating a new store for every test and overriding the dep injection function
 	suite.store = store.GetStore()
 	store.GetStore = func() store.Store { return suite.store }
+}
+
+func (suite *RegistrationTestSuite) AfterTest(_, _ string) {
+	suite.rec.Result().Body.Close()
 }
 
 func TestRegistrationsEndpoint(t *testing.T) {
@@ -37,46 +44,49 @@ func TestRegistrationsEndpoint(t *testing.T) {
 
 func (suite *RegistrationTestSuite) TestEmptyBody() {
 	body := []byte(`{}`)
-	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body))
+	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body)).
+		WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{}))
 	RegistrationHandler(suite.rec, req)
+
+	//nolint:bodyclose
 	suite.Equal(http.StatusBadRequest, suite.rec.Result().StatusCode)
 }
 
 func (suite *RegistrationTestSuite) TestNoBody() {
 	body := []byte(``)
-	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body))
+	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body)).
+		WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{}))
 	RegistrationHandler(suite.rec, req)
+
+	//nolint:bodyclose
 	suite.Equal(http.StatusBadRequest, suite.rec.Result().StatusCode)
 }
 
 func (suite *RegistrationTestSuite) TestBadBody() {
 	body := []byte(`{`)
-	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body))
+	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body)).
+		WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{}))
 	RegistrationHandler(suite.rec, req)
+
+	//nolint:bodyclose
 	suite.Equal(http.StatusBadRequest, suite.rec.Result().StatusCode)
 }
 
-func (suite *RegistrationTestSuite) TestNoToken() {
-	body := []byte(`{"uid": "abc1234"}`)
-	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body))
-	RegistrationHandler(suite.rec, req)
-	suite.Equal(http.StatusBadRequest, suite.rec.Result().StatusCode)
-}
+func (suite *RegistrationTestSuite) TestNotOrgAdmin() {
+	_, err := suite.store.Create(&store.Registration{UID: "abc1234"})
+	suite.Nil(err)
 
-func (suite *RegistrationTestSuite) TestNonBearerToken() {
 	body := []byte(`{"uid": "abc1234"}`)
-	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body))
-	req.Header.Add("Authorization", "TrustmeBro 1234")
-	RegistrationHandler(suite.rec, req)
-	suite.Equal(http.StatusBadRequest, suite.rec.Result().StatusCode)
-}
+	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body)).
+		WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{Identity: identity.Identity{
+			User:  identity.User{OrgAdmin: false},
+			OrgID: "1234",
+		}}))
 
-func (suite *RegistrationTestSuite) TestBadToken() {
-	body := []byte(`{"uid": "abc1234"}`)
-	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body))
-	req.Header.Add("Authorization", "TrustmeBro1234")
 	RegistrationHandler(suite.rec, req)
-	suite.Equal(http.StatusBadRequest, suite.rec.Result().StatusCode)
+
+	//nolint:bodyclose
+	suite.Equal(http.StatusUnauthorized, suite.rec.Result().StatusCode)
 }
 
 func (suite *RegistrationTestSuite) TestExistingRegistration() {
@@ -84,19 +94,28 @@ func (suite *RegistrationTestSuite) TestExistingRegistration() {
 	suite.Nil(err)
 
 	body := []byte(`{"uid": "abc1234"}`)
-	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body))
-	req.Header.Add("Authorization", "Bearer 1234")
+	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body)).
+		WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{Identity: identity.Identity{
+			User:  identity.User{OrgAdmin: true},
+			OrgID: "1234",
+		}}))
 
 	RegistrationHandler(suite.rec, req)
 
+	//nolint:bodyclose
 	suite.Equal(http.StatusConflict, suite.rec.Result().StatusCode)
 }
 
 func (suite *RegistrationTestSuite) TestSuccessfulRegistration() {
 	body := []byte(`{"uid": "abc1234"}`)
-	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body))
-	req.Header.Add("Authorization", "Bearer 1234")
+	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body)).
+		WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{Identity: identity.Identity{
+			User:  identity.User{OrgAdmin: true},
+			OrgID: "1234",
+		}}))
 
 	RegistrationHandler(suite.rec, req)
+
+	//nolint:bodyclose
 	suite.Equal(http.StatusCreated, suite.rec.Result().StatusCode)
 }

--- a/internal/handlers/registration_handler_test.go
+++ b/internal/handlers/registration_handler_test.go
@@ -1,0 +1,102 @@
+package handlers
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/redhatinsights/mbop/internal/config"
+	"github.com/redhatinsights/mbop/internal/store"
+	"github.com/stretchr/testify/suite"
+)
+
+type RegistrationTestSuite struct {
+	suite.Suite
+	rec   *httptest.ResponseRecorder
+	store store.Store
+}
+
+func (suite *RegistrationTestSuite) SetupSuite() {
+	config.Reset()
+	os.Setenv("STORE_BACKEND", "memory")
+}
+
+func (suite *RegistrationTestSuite) BeforeTest(_, _ string) {
+	suite.rec = httptest.NewRecorder()
+	suite.Nil(store.SetupStore())
+
+	suite.store = store.GetStore()
+	store.GetStore = func() store.Store { return suite.store }
+}
+
+func TestRegistrationsEndpoint(t *testing.T) {
+	suite.Run(t, new(RegistrationTestSuite))
+}
+
+func (suite *RegistrationTestSuite) TestEmptyBody() {
+	body := []byte(`{}`)
+	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body))
+	RegistrationHandler(suite.rec, req)
+	suite.Equal(http.StatusBadRequest, suite.rec.Result().StatusCode)
+}
+
+func (suite *RegistrationTestSuite) TestNoBody() {
+	body := []byte(``)
+	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body))
+	RegistrationHandler(suite.rec, req)
+	suite.Equal(http.StatusBadRequest, suite.rec.Result().StatusCode)
+}
+
+func (suite *RegistrationTestSuite) TestBadBody() {
+	body := []byte(`{`)
+	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body))
+	RegistrationHandler(suite.rec, req)
+	suite.Equal(http.StatusBadRequest, suite.rec.Result().StatusCode)
+}
+
+func (suite *RegistrationTestSuite) TestNoToken() {
+	body := []byte(`{"uid": "abc1234"}`)
+	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body))
+	RegistrationHandler(suite.rec, req)
+	suite.Equal(http.StatusBadRequest, suite.rec.Result().StatusCode)
+}
+
+func (suite *RegistrationTestSuite) TestNonBearerToken() {
+	body := []byte(`{"uid": "abc1234"}`)
+	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body))
+	req.Header.Add("Authorization", "TrustmeBro 1234")
+	RegistrationHandler(suite.rec, req)
+	suite.Equal(http.StatusBadRequest, suite.rec.Result().StatusCode)
+}
+
+func (suite *RegistrationTestSuite) TestBadToken() {
+	body := []byte(`{"uid": "abc1234"}`)
+	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body))
+	req.Header.Add("Authorization", "TrustmeBro1234")
+	RegistrationHandler(suite.rec, req)
+	suite.Equal(http.StatusBadRequest, suite.rec.Result().StatusCode)
+}
+
+func (suite *RegistrationTestSuite) TestExistingRegistration() {
+	_, err := suite.store.Create(&store.Registration{UID: "abc1234"})
+	suite.Nil(err)
+
+	body := []byte(`{"uid": "abc1234"}`)
+	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body))
+	req.Header.Add("Authorization", "Bearer 1234")
+
+	RegistrationHandler(suite.rec, req)
+
+	suite.Equal(http.StatusConflict, suite.rec.Result().StatusCode)
+}
+
+func (suite *RegistrationTestSuite) TestSuccessfulRegistration() {
+	body := []byte(`{"uid": "abc1234"}`)
+	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body))
+	req.Header.Add("Authorization", "Bearer 1234")
+
+	RegistrationHandler(suite.rec, req)
+	suite.Equal(http.StatusCreated, suite.rec.Result().StatusCode)
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -11,7 +11,10 @@ import (
 
 // GetStore is a function that will return the currently configured store. this
 // allows it to be overridden for testing or alternative implementations
-var GetStore func() (Store, error)
+var GetStore func() Store
+
+// persistent ref to an in-memory store if present
+var mem Store
 
 func SetupStore() error {
 	switch config.Get().StoreBackend {
@@ -21,9 +24,10 @@ func SetupStore() error {
 			return err
 		}
 
-		GetStore = func() (Store, error) { return pgStore, nil }
+		GetStore = func() Store { return pgStore }
 	case "memory":
-		GetStore = func() (Store, error) { return &inMemoryStore{}, nil }
+		mem = &inMemoryStore{}
+		GetStore = func() Store { return mem }
 	}
 
 	return nil


### PR DESCRIPTION
**DEPENDENCY:** Built off of #34, so that needs to go in first.

---

This adds the endpoint for `POST /v1/registrations` which allows a satellite to associate an orgid from a cognito token with a satellite cert cn (uid).

\# TODO:
- [x] build out endpoint
- [x] ~fetch orgID from token from AMS~ pulling from xrhid instead
- [x] store registration
- [x] tests