### PR TITLE
Expand /users mock implementation

### DIFF
--- a/internal/handlers/constants.go
+++ b/internal/handlers/constants.go
@@ -6,3 +6,4 @@ Constants used throughout the handlers package, will probably mostly be module d
 
 const awsModule = "aws"
 const amsModule = "ams"
+const mockModule = "mock"

--- a/internal/handlers/users_v1_handler.go
+++ b/internal/handlers/users_v1_handler.go
@@ -15,7 +15,7 @@ func UsersV1Handler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	switch config.Get().UsersModule {
-	case amsModule:
+	case amsModule, mockModule:
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			do500(w, "failed to read request body: "+err.Error())
@@ -24,7 +24,7 @@ func UsersV1Handler(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 
 		var usernames models.UserBody
-		err = json.Unmarshal(body, &usernames)
+		err = json.Unmarshal([]byte(body), &usernames)
 		if err != nil {
 			do400(w, "failed to parse request body: "+err.Error()+", request must include 'usernames': [] ")
 			return

--- a/internal/handlers/users_v1_handler.go
+++ b/internal/handlers/users_v1_handler.go
@@ -24,7 +24,7 @@ func UsersV1Handler(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 
 		var usernames models.UserBody
-		err = json.Unmarshal([]byte(body), &usernames)
+		err = json.Unmarshal(body, &usernames)
 		if err != nil {
 			do400(w, "failed to parse request body: "+err.Error()+", request must include 'usernames': [] ")
 			return

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -28,7 +28,7 @@ type UserQuery struct {
 }
 
 type UserBody struct {
-	Usernames []string `json:"usernames"`
+	Users []string `json:"users"`
 }
 
 func (u *Users) AddUser(user User) {

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -28,7 +28,7 @@ type UserQuery struct {
 }
 
 type UserBody struct {
-	Users []string `json:"users"`
+	Usernames []string `json:"usernames"`
 }
 
 func (u *Users) AddUser(user User) {

--- a/internal/service/ocm/ocm_impl.go
+++ b/internal/service/ocm/ocm_impl.go
@@ -126,15 +126,15 @@ func responseToUsers(response *v1.AccountsListResponse) models.Users {
 	return users
 }
 
-func createSearchString(usernames models.UserBody) string {
+func createSearchString(u models.UserBody) string {
 	search := ""
 
-	for i := range usernames.Users {
+	for i := range u.Usernames {
 		if i > 0 {
 			search += " or "
 		}
 
-		search += fmt.Sprintf("username='%s'", usernames.Users[i])
+		search += fmt.Sprintf("username='%s'", u.Usernames[i])
 	}
 
 	return search

--- a/internal/service/ocm/ocm_impl.go
+++ b/internal/service/ocm/ocm_impl.go
@@ -129,12 +129,12 @@ func responseToUsers(response *v1.AccountsListResponse) models.Users {
 func createSearchString(u models.UserBody) string {
 	search := ""
 
-	for i := range u.Usernames {
+	for i := range u.Users {
 		if i > 0 {
 			search += " or "
 		}
 
-		search += fmt.Sprintf("username='%s'", u.Usernames[i])
+		search += fmt.Sprintf("username='%s'", u.Users[i])
 	}
 
 	return search

--- a/internal/service/ocm/ocm_interface.go
+++ b/internal/service/ocm/ocm_interface.go
@@ -17,6 +17,7 @@ type OCM interface {
 
 // re-declaring ams constant here to avoid circular module importing
 const amsModule = "ams"
+const mockModule = "mock"
 
 func NewOcmClient() (OCM, error) {
 	var client OCM
@@ -24,7 +25,7 @@ func NewOcmClient() (OCM, error) {
 	switch config.Get().UsersModule {
 	case amsModule:
 		client = &SDK{}
-	case "mock":
+	case mockModule:
 		client = &SDKMock{}
 	default:
 		return nil, fmt.Errorf("unsupported users module %q", config.Get().UsersModule)

--- a/internal/service/ocm/ocm_mock.go
+++ b/internal/service/ocm/ocm_mock.go
@@ -39,7 +39,7 @@ func (ocm *SDKMock) GetUsers(u models.UserBody, q models.UserQuery) (models.User
 			IsInternal:    true,
 			Locale:        "en_US",
 			OrgID:         strconv.Itoa(rand.Intn(999999 - 100000)),
-			DisplayName:   "FedRAMP1",
+			DisplayName:   "FedRAMP" + strconv.Itoa(rand.Intn(90-0)),
 			Type:          "User",
 		})
 	}

--- a/internal/service/ocm/ocm_mock.go
+++ b/internal/service/ocm/ocm_mock.go
@@ -3,7 +3,10 @@ package ocm
 import (
 	"context"
 	"fmt"
+	"math/rand"
+	"strconv"
 
+	"github.com/google/uuid"
 	"github.com/redhatinsights/mbop/internal/models"
 )
 
@@ -13,48 +16,32 @@ func (ocm *SDKMock) InitSdkConnection(ctx context.Context) error {
 	return nil
 }
 
-func (ocm *SDKMock) GetUsers(usernames models.UserBody, q models.UserQuery) (models.Users, error) {
+func (ocm *SDKMock) GetUsers(u models.UserBody, q models.UserQuery) (models.Users, error) {
 	var users models.Users
 
-	if usernames.Users == nil {
+	if u.Usernames == nil {
 		return users, nil
 	}
 
-	if usernames.Users[0] == "errorTest" {
+	if u.Usernames[0] == "errorTest" {
 		return users, fmt.Errorf("internal AMS Error")
 	}
 
-	users = models.Users{
-		Users: []models.User{
-			{
-				Username:      "test1",
-				ID:            "12345",
-				Email:         "lub@dub.com",
-				FirstName:     "test",
-				LastName:      "case",
-				AddressString: "https://something.com",
-				IsActive:      true,
-				IsInternal:    true,
-				Locale:        "en_US",
-				OrgID:         "67890",
-				DisplayName:   "FedRAMP1",
-				Type:          "User",
-			},
-			{
-				Username:      "test2",
-				ID:            "23456",
-				Email:         "lub@dub.com",
-				FirstName:     "john",
-				LastName:      "doe",
-				AddressString: "https://something.com",
-				IsActive:      true,
-				IsInternal:    true,
-				Locale:        "en_US",
-				OrgID:         "78901",
-				DisplayName:   "FedRAMP2",
-				Type:          "User",
-			},
-		},
+	for _, user := range u.Usernames {
+		users.AddUser(models.User{
+			Username:      user,
+			ID:            uuid.New().String(),
+			Email:         "lub@dub.com",
+			FirstName:     "test",
+			LastName:      "case",
+			AddressString: "https://usersTest.com",
+			IsActive:      true,
+			IsInternal:    true,
+			Locale:        "en_US",
+			OrgID:         strconv.Itoa(rand.Intn(999999 - 100000)),
+			DisplayName:   "FedRAMP1",
+			Type:          "User",
+		})
 	}
 
 	return users, nil
@@ -71,11 +58,11 @@ func (ocm *SDKMock) GetOrgAdmin(users []models.User) (models.OrgAdminResponse, e
 		return response, fmt.Errorf("error retrieving Role Bindings")
 	}
 
-	response = models.OrgAdminResponse{
-		"12345": models.OrgAdmin{
-			ID:         "12345",
+	for _, user := range users {
+		response[user.ID] = models.OrgAdmin{
+			ID:         user.ID,
 			IsOrgAdmin: true,
-		},
+		}
 	}
 
 	return response, nil

--- a/internal/service/ocm/ocm_mock.go
+++ b/internal/service/ocm/ocm_mock.go
@@ -20,15 +20,15 @@ func (ocm *SDKMock) InitSdkConnection(ctx context.Context) error {
 func (ocm *SDKMock) GetUsers(u models.UserBody, q models.UserQuery) (models.Users, error) {
 	var users models.Users
 
-	if u.Usernames == nil {
+	if u.Users == nil {
 		return users, nil
 	}
 
-	if u.Usernames[0] == "errorTest" {
+	if u.Users[0] == "errorTest" {
 		return users, fmt.Errorf("internal AMS Error")
 	}
 
-	for _, user := range u.Usernames {
+	for _, user := range u.Users {
 		orgID, err := rand.Int(rand.Reader, big.NewInt(999999-100000))
 		if err != nil {
 			return users, err

--- a/internal/service/ocm/ocm_mock.go
+++ b/internal/service/ocm/ocm_mock.go
@@ -2,8 +2,9 @@ package ocm
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"strconv"
 
 	"github.com/google/uuid"
@@ -28,6 +29,16 @@ func (ocm *SDKMock) GetUsers(u models.UserBody, q models.UserQuery) (models.User
 	}
 
 	for _, user := range u.Usernames {
+		orgID, err := rand.Int(rand.Reader, big.NewInt(999999-100000))
+		if err != nil {
+			return users, err
+		}
+
+		displayNameNum, err := rand.Int(rand.Reader, big.NewInt(99-0))
+		if err != nil {
+			return users, err
+		}
+
 		users.AddUser(models.User{
 			Username:      user,
 			ID:            uuid.New().String(),
@@ -38,8 +49,8 @@ func (ocm *SDKMock) GetUsers(u models.UserBody, q models.UserQuery) (models.User
 			IsActive:      true,
 			IsInternal:    true,
 			Locale:        "en_US",
-			OrgID:         strconv.Itoa(rand.Intn(999999 - 100000)),
-			DisplayName:   "FedRAMP" + strconv.Itoa(rand.Intn(90-0)),
+			OrgID:         strconv.Itoa(int(orgID.Int64())),
+			DisplayName:   "FedRAMP" + strconv.Itoa(int(displayNameNum.Int64())),
 			Type:          "User",
 		})
 	}


### PR DESCRIPTION
Expanded the mock implementation of the /v1/users endpoint to allow for a user to specify the USERS_MODULE = "mock".

Once this is done the request body can be sent with any usernames of the users choice, i.e.

```
{
   "users": [test1, test2]
}
```

and the response will be a list of users with the usernames specified in the request body i.e.
```
[
    {
        "username": "test1",
        "id": "4a7d63a0-1bd6-4402-9f22-e9aa3d622fd4",
        "email": "lub@dub.com",
        "first_name": "test",
        "last_name": "case",
        "account_number": "",
        "address_string": "https://usersTest.com",
        "is_active": true,
        "is_org_admin": true,
        "is_internal": true,
        "locale": "en_US",
        "org_id": "699523",
        "display_name": "FedRAMP1",
        "entitlements": "",
        "type": "User"
    },
    {
        "username": "test2",
        "id": "dacabe99-5264-4c55-97a7-5a72b6a01b2d",
        "email": "lub@dub.com",
        "first_name": "test",
        "last_name": "case",
        "account_number": "",
        "address_string": "https://usersTest.com",
        "is_active": true,
        "is_org_admin": true,
        "is_internal": true,
        "locale": "en_US",
        "org_id": "130131",
        "display_name": "FedRAMP1",
        "entitlements": "",
        "type": "User"
    }
]
```