### PR TITLE
Add accounts v3 users endpoint

### DIFF
--- a/cmd/mbop/mbop.go
+++ b/cmd/mbop/mbop.go
@@ -31,6 +31,7 @@ func main() {
 	r.Get("/v1/jwt", handlers.JWTV1Handler)
 	r.Post("/v1/users", handlers.UsersV1Handler)
 	r.Post("/v1/sendEmails", handlers.SendEmails)
+	r.Get("/v3/accounts/{orgID}/users", handlers.AccountsV3UsersHandler)
 
 	err := mailer.InitConfig()
 	if err != nil {

--- a/internal/handlers/accounts_v3_users_handler.go
+++ b/internal/handlers/accounts_v3_users_handler.go
@@ -1,36 +1,25 @@
 package handlers
 
 import (
-	"encoding/json"
-	"io"
 	"net/http"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/redhatinsights/mbop/internal/config"
 	"github.com/redhatinsights/mbop/internal/service/ocm"
-
-	"github.com/redhatinsights/mbop/internal/models"
 )
 
-func UsersV1Handler(w http.ResponseWriter, r *http.Request) {
+func AccountsV3UsersHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	switch config.Get().UsersModule {
-	case amsModule, mockModule:
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			do500(w, "failed to read request body: "+err.Error())
-			return
-		}
-		defer r.Body.Close()
-
-		var usernames models.UserBody
-		err = json.Unmarshal(body, &usernames)
-		if err != nil {
-			do400(w, "failed to parse request body: "+err.Error()+", request must include 'users': [] ")
+	case amsModule:
+		orgID := chi.URLParam(r, "orgID")
+		if orgID == "" {
+			do400(w, "Request URL must include orgID: /v3/accounts/{orgID}/users")
 			return
 		}
 
-		q, err := initV1UserQuery(r)
+		q, err := initAccountV3UserQuery(r)
 		if err != nil {
 			do400(w, err.Error())
 			return
@@ -49,9 +38,9 @@ func UsersV1Handler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		u, err := client.GetUsers(usernames, q)
+		u, err := client.GetAccountV3Users(orgID, q)
 		if err != nil {
-			do500(w, "Cant Retrieve Accounts: "+err.Error())
+			do500(w, "Cant Retrieve Users: "+err.Error())
 			return
 		}
 
@@ -68,11 +57,11 @@ func UsersV1Handler(w http.ResponseWriter, r *http.Request) {
 				u.Users[i].IsOrgAdmin = response.IsOrgAdmin
 			} else {
 				user.IsOrgAdmin = false
+				if q.AdminOnly { // if admin_only return only the org_admins
+					u.RemoveUser(i)
+				}
 			}
 		}
-
-		// Close SDK Connection
-		client.CloseSdkConnection()
 
 		sendJSON(w, u.Users)
 	default:

--- a/internal/handlers/accounts_v3_users_handler.go
+++ b/internal/handlers/accounts_v3_users_handler.go
@@ -12,7 +12,7 @@ func AccountsV3UsersHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	switch config.Get().UsersModule {
-	case amsModule:
+	case amsModule, mockModule:
 		orgID := chi.URLParam(r, "orgID")
 		if orgID == "" {
 			do400(w, "Request URL must include orgID: /v3/accounts/{orgID}/users")
@@ -63,7 +63,9 @@ func AccountsV3UsersHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		sendJSON(w, u.Users)
+		r := usersToV3Response(u.Users)
+
+		sendJSON(w, r.Responses)
 	default:
 		// mbop server instance injected somewhere
 		// pass right through to the current handler

--- a/internal/handlers/constants.go
+++ b/internal/handlers/constants.go
@@ -7,3 +7,6 @@ Constants used throughout the handlers package, will probably mostly be module d
 const awsModule = "aws"
 const amsModule = "ams"
 const mockModule = "mock"
+
+const defaultLimit = 100
+const defaultOffset = 0

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -132,9 +132,9 @@ func getSortOrder(r *http.Request) (string, error) {
 		} else {
 			return r.URL.Query().Get("sortOrder"), nil
 		}
-	} else {
-		return "", fmt.Errorf("sortOrder must be one of '', " + strings.Join(validSortOrder, ", "))
 	}
+
+	return "", fmt.Errorf("sortOrder must be one of '', " + strings.Join(validSortOrder, ", "))
 }
 
 func getQueryBy(r *http.Request) (string, error) {
@@ -158,9 +158,9 @@ func getAdminOnly(r *http.Request) (bool, error) {
 	if r.URL.Query().Get("admin_only") == "" || stringInSlice(r.URL.Query().Get("admin_only"), validAdminOnly) {
 		if r.URL.Query().Get("admin_only") == validAdminOnly[0] {
 			return true, nil
-		} else {
-			return false, nil
 		}
+
+		return false, nil
 	} else {
 		return false, fmt.Errorf("admin_only must be one of " + strings.Join(validSortOrder, ", "))
 	}

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -106,6 +106,25 @@ func initAccountV3UserQuery(r *http.Request) (models.UserV3Query, error) {
 	return q, nil
 }
 
+func usersToV3Response(users []models.User) models.UserV3Responses {
+	r := models.UserV3Responses{}
+
+	for _, user := range users {
+		r.AddV3Response(models.UserV3Response{
+			ID:         user.OrgID,
+			Email:      user.Email,
+			Username:   user.Username,
+			FirstName:  user.FirstName,
+			LastName:   user.LastName,
+			IsActive:   user.IsActive,
+			IsInternal: user.IsInternal,
+			Locale:     user.Locale,
+		})
+	}
+
+	return r
+}
+
 func getSortOrder(r *http.Request) (string, error) {
 	if r.URL.Query().Get("sortOrder") == "" || stringInSlice(r.URL.Query().Get("sortOrder"), validSortOrder) {
 		if r.URL.Query().Get("sortOrder") == validSortOrder[1] {
@@ -145,8 +164,6 @@ func getAdminOnly(r *http.Request) (bool, error) {
 	} else {
 		return false, fmt.Errorf("admin_only must be one of " + strings.Join(validSortOrder, ", "))
 	}
-
-	return false, nil
 }
 
 func getLimit(r *http.Request) (int, error) {
@@ -154,7 +171,7 @@ func getLimit(r *http.Request) (int, error) {
 		return defaultLimit, nil
 	}
 
-	limit, err := strconv.Atoi(r.URL.Query().Get("admin_only"))
+	limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
 	if err != nil {
 		return defaultLimit, fmt.Errorf("limit must be of type int")
 	}

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -129,9 +129,9 @@ func getSortOrder(r *http.Request) (string, error) {
 	if r.URL.Query().Get("sortOrder") == "" || stringInSlice(r.URL.Query().Get("sortOrder"), validSortOrder) {
 		if r.URL.Query().Get("sortOrder") == validSortOrder[1] {
 			return "desc", nil
-		} else {
-			return r.URL.Query().Get("sortOrder"), nil
 		}
+
+		return r.URL.Query().Get("sortOrder"), nil
 	}
 
 	return "", fmt.Errorf("sortOrder must be one of '', " + strings.Join(validSortOrder, ", "))
@@ -161,9 +161,9 @@ func getAdminOnly(r *http.Request) (bool, error) {
 		}
 
 		return false, nil
-	} else {
-		return false, fmt.Errorf("admin_only must be one of " + strings.Join(validSortOrder, ", "))
 	}
+
+	return false, fmt.Errorf("admin_only must be one of " + strings.Join(validSortOrder, ", "))
 }
 
 func getLimit(r *http.Request) (int, error) {

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -111,12 +111,13 @@ func usersToV3Response(users []models.User) models.UserV3Responses {
 
 	for _, user := range users {
 		r.AddV3Response(models.UserV3Response{
-			ID:         user.OrgID,
+			ID:         user.ID,
 			Email:      user.Email,
 			Username:   user.Username,
 			FirstName:  user.FirstName,
 			LastName:   user.LastName,
 			IsActive:   user.IsActive,
+			IsOrgAdmin: user.IsOrgAdmin,
 			IsInternal: user.IsInternal,
 			Locale:     user.Locale,
 		})

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 
 	l "github.com/redhatinsights/mbop/internal/logger"
@@ -13,6 +14,7 @@ import (
 var (
 	validSortOrder = []string{"asc", "des"}
 	validQueryBy   = []string{"userId", "orgId"} // Originally orgId was "principal" but in FedRAMP cluster we only have orgId
+	validAdminOnly = []string{"true", "false"}
 )
 
 func sendJSON(w http.ResponseWriter, data any) {
@@ -54,31 +56,121 @@ func stringInSlice(a string, list []string) bool {
 	return false
 }
 
-func initUserQuery(r *http.Request) (models.UserQuery, error) {
-	q := models.UserQuery{}
+func initV1UserQuery(r *http.Request) (models.UserV1Query, error) {
+	q := models.UserV1Query{}
 
-	if r.URL.Query().Get("sortOrder") == "" || stringInSlice(r.URL.Query().Get("sortOrder"), validSortOrder) {
-		if r.URL.Query().Get("sortOrder") == validSortOrder[1] {
-			q.SortOrder = "desc"
-		} else {
-			q.SortOrder = r.URL.Query().Get("sortOrder")
-		}
-	} else {
-		return q, fmt.Errorf("sortOrder must be one of '', " + strings.Join(validSortOrder, ", "))
+	sortOrder, err := getSortOrder(r)
+	if err != nil {
+		return q, err
 	}
 
+	queryBy, err := getQueryBy(r)
+	if err != nil {
+		return q, err
+	}
+
+	q.SortOrder = sortOrder
+	q.QueryBy = queryBy
+
+	return q, nil
+}
+
+func initAccountV3UserQuery(r *http.Request) (models.UserV3Query, error) {
+	q := models.UserV3Query{}
+
+	sortOrder, err := getSortOrder(r)
+	if err != nil {
+		return q, err
+	}
+
+	adminOnly, err := getAdminOnly(r)
+	if err != nil {
+		return q, err
+	}
+
+	limit, err := getLimit(r)
+	if err != nil {
+		return q, err
+	}
+
+	offset, err := getOffset(r)
+	if err != nil {
+		return q, err
+	}
+
+	q.SortOrder = sortOrder
+	q.AdminOnly = adminOnly
+	q.Limit = limit
+	q.Offset = offset
+
+	return q, nil
+}
+
+func getSortOrder(r *http.Request) (string, error) {
+	if r.URL.Query().Get("sortOrder") == "" || stringInSlice(r.URL.Query().Get("sortOrder"), validSortOrder) {
+		if r.URL.Query().Get("sortOrder") == validSortOrder[1] {
+			return "desc", nil
+		} else {
+			return r.URL.Query().Get("sortOrder"), nil
+		}
+	} else {
+		return "", fmt.Errorf("sortOrder must be one of '', " + strings.Join(validSortOrder, ", "))
+	}
+}
+
+func getQueryBy(r *http.Request) (string, error) {
 	if r.URL.Query().Get("queryBy") == "" || stringInSlice(r.URL.Query().Get("queryBy"), validQueryBy) {
 		// Translate bop parameters into AMS parameters
 		if r.URL.Query().Get("queryBy") == validQueryBy[0] {
-			q.QueryBy = "id"
+			return "id", nil
 		}
 
 		if r.URL.Query().Get("queryBy") == validQueryBy[1] {
-			q.QueryBy = "organizationId"
+			return "organizationId", nil
 		}
 	} else {
-		return q, fmt.Errorf("queryBy must be one of " + strings.Join(validQueryBy, ", "))
+		return "", fmt.Errorf("queryBy must be one of " + strings.Join(validQueryBy, ", "))
 	}
 
-	return q, nil
+	return "", nil
+}
+
+func getAdminOnly(r *http.Request) (bool, error) {
+	if r.URL.Query().Get("admin_only") == "" || stringInSlice(r.URL.Query().Get("admin_only"), validAdminOnly) {
+		if r.URL.Query().Get("admin_only") == validAdminOnly[0] {
+			return true, nil
+		} else {
+			return false, nil
+		}
+	} else {
+		return false, fmt.Errorf("admin_only must be one of " + strings.Join(validSortOrder, ", "))
+	}
+
+	return false, nil
+}
+
+func getLimit(r *http.Request) (int, error) {
+	if r.URL.Query().Get("limit") == "" {
+		return defaultLimit, nil
+	}
+
+	limit, err := strconv.Atoi(r.URL.Query().Get("admin_only"))
+	if err != nil {
+		return defaultLimit, fmt.Errorf("limit must be of type int")
+	}
+
+	return limit, nil
+}
+
+func getOffset(r *http.Request) (int, error) {
+	if r.URL.Query().Get("offset") == "" {
+		return defaultOffset, nil
+	}
+
+	offset, err := strconv.Atoi(r.URL.Query().Get("offset"))
+	if err != nil {
+		return defaultLimit, fmt.Errorf("offset must be of type int")
+	}
+
+	return offset, nil
 }

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -33,6 +33,7 @@ type UserV3Response struct {
 	FirstName  string `json:"first_name"`
 	LastName   string `json:"last_name"`
 	IsActive   bool   `json:"is_active"`
+	IsOrgAdmin bool   `json:"is_org_admin"`
 	IsInternal bool   `json:"is_internal"`
 	Locale     string `json:"locale"`
 }

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -4,6 +4,10 @@ type Users struct {
 	Users []User `json:"users,omitempty"`
 }
 
+type UserV3Responses struct {
+	Responses []UserV3Response `json:"responses,omitempty"`
+}
+
 type User struct {
 	Username      string `json:"username"`
 	ID            string `json:"id"`
@@ -20,6 +24,17 @@ type User struct {
 	DisplayName   string `json:"display_name"`
 	Entitlements  string `json:"entitlements"`
 	Type          string `json:"type"`
+}
+
+type UserV3Response struct {
+	ID         string `json:"id"`
+	Username   string `json:"username"`
+	Email      string `json:"email"`
+	FirstName  string `json:"first_name"`
+	LastName   string `json:"last_name"`
+	IsActive   bool   `json:"is_active"`
+	IsInternal bool   `json:"is_internal"`
+	Locale     string `json:"locale"`
 }
 
 type UserV1Query struct {
@@ -44,4 +59,8 @@ func (u *Users) AddUser(user User) {
 
 func (u *Users) RemoveUser(index int) {
 	u.Users = append(u.Users[:index], u.Users[index+1:]...)
+}
+
+func (r *UserV3Responses) AddV3Response(response UserV3Response) {
+	r.Responses = append(r.Responses, response)
 }

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -22,9 +22,16 @@ type User struct {
 	Type          string `json:"type"`
 }
 
-type UserQuery struct {
+type UserV1Query struct {
 	SortOrder string `json:"sortOrder"`
 	QueryBy   string `json:"queryBy"`
+}
+
+type UserV3Query struct {
+	SortOrder string `json:"sortOrder"`
+	AdminOnly bool   `json:"admin_only"`
+	Limit     int    `json:"limit"`
+	Offset    int    `json:"offset"`
 }
 
 type UserBody struct {
@@ -33,4 +40,8 @@ type UserBody struct {
 
 func (u *Users) AddUser(user User) {
 	u.Users = append(u.Users, user)
+}
+
+func (u *Users) RemoveUser(index int) {
+	u.Users = append(u.Users[:index], u.Users[index+1:]...)
 }

--- a/internal/service/ocm/ocm_impl.go
+++ b/internal/service/ocm/ocm_impl.go
@@ -177,7 +177,7 @@ func createOrgAdminSearchString(users []models.User) string {
 }
 
 func createAccountsV3UsersSearchString(orgID string) string {
-	return fmt.Sprintf("organization.id='%s'", orgID)
+	return fmt.Sprintf(OrganizationID+"='%s'", orgID)
 }
 
 func createQueryOrder(q models.UserV1Query) string {
@@ -194,9 +194,9 @@ func createQueryOrder(q models.UserV1Query) string {
 	return order
 }
 
-func createV3QueryOrder(q models.UserV3Query) string {
-	order := OrganizationID
+var order = OrganizationID
 
+func createV3QueryOrder(q models.UserV3Query) string {
 	if q.SortOrder != "" {
 		order += fmt.Sprint(" " + q.SortOrder)
 	}

--- a/internal/service/ocm/ocm_impl.go
+++ b/internal/service/ocm/ocm_impl.go
@@ -146,23 +146,6 @@ func responseToUsers(response *v1.AccountsListResponse) models.Users {
 	return users
 }
 
-func usersToV3Response(u models.Users) models.UserV3Response {
-	response := models.UserV3Response{}
-
-	for _, user := range u.Users {
-		response.ID = user.OrgID
-		response.Email = user.Email
-		response.Username = user.Username
-		response.FirstName = user.FirstName
-		response.LastName = user.LastName
-		response.IsActive = user.IsActive
-		response.IsInternal = user.IsInternal
-		response.Locale = user.Locale
-	}
-
-	return response
-}
-
 func createSearchString(u models.UserBody) string {
 	search := ""
 

--- a/internal/service/ocm/ocm_impl.go
+++ b/internal/service/ocm/ocm_impl.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	v1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	"github.com/openshift-online/ocm-sdk-go/logging"
+	"github.com/redhatinsights/mbop/internal/config"
 	"github.com/redhatinsights/mbop/internal/models"
 )
 
@@ -28,23 +29,19 @@ func (ocm *SDK) InitSdkConnection(ctx context.Context) error {
 		Logger(logger).
 
 		// SA Auth:
-		// Client(os.Getenv("COGNITO_APP_CLIENT_ID"), os.Getenv("COGNITO_APP_CLIENT_SECRET")).
-		Client("6k2fo38r9l306k9l2t1ji428jo", "1f8ontqbalms06td5375trbc1g2rmgmficeo146u2s6odinr9b2q").
+		Client(config.Get().CognitoAppClientID, config.Get().CognitoAppClientSecret).
 
 		// Offline Token Auth:
 		// Tokens(<token>).
 
 		// Oauth Token URL:
-		// TokenURL(os.Getenv("OAUTH_TOKEN_URL")).
-		TokenURL("https://ocm-ra-stage-domain.auth-fips.us-gov-west-1.amazoncognito.com/oauth2/token").
+		TokenURL(config.Get().OauthTokenURL).
 
 		// Route to hit for AMS:
-		// URL(os.Getenv("AMS_URL")).
-		URL("https://ocm-stage.rosa-nlb.appsrefrs01ugw1.p1.openshiftusgov.com").
+		URL(config.Get().AmsURL).
 
 		// SA Scopes:
-		// Scopes(os.Getenv("COGNITO_SCOPE")).
-		Scopes("ocm/InsightsServiceAccount").
+		Scopes(config.Get().CognitoScope).
 		BuildContext(ctx)
 
 	if err != nil {

--- a/internal/service/ocm/ocm_impl.go
+++ b/internal/service/ocm/ocm_impl.go
@@ -11,6 +11,8 @@ import (
 	"github.com/redhatinsights/mbop/internal/models"
 )
 
+const OrganizationID = "organization.id"
+
 type SDK struct {
 	client *sdk.Connection
 }
@@ -193,7 +195,7 @@ func createQueryOrder(q models.UserV1Query) string {
 }
 
 func createV3QueryOrder(q models.UserV3Query) string {
-	order := "organization.id"
+	order := OrganizationID
 
 	if q.SortOrder != "" {
 		order += fmt.Sprint(" " + q.SortOrder)

--- a/internal/service/ocm/ocm_interface.go
+++ b/internal/service/ocm/ocm_interface.go
@@ -11,7 +11,8 @@ import (
 type OCM interface {
 	InitSdkConnection(ctx context.Context) error
 	CloseSdkConnection()
-	GetUsers(users models.UserBody, q models.UserQuery) (models.Users, error)
+	GetUsers(users models.UserBody, q models.UserV1Query) (models.Users, error)
+	GetAccountV3Users(orgID string, q models.UserV3Query) (models.Users, error)
 	GetOrgAdmin([]models.User) (models.OrgAdminResponse, error)
 }
 

--- a/internal/service/ocm/ocm_mock.go
+++ b/internal/service/ocm/ocm_mock.go
@@ -80,11 +80,37 @@ func (ocm *SDKMock) GetOrgAdmin(users []models.User) (models.OrgAdminResponse, e
 }
 
 func (ocm *SDKMock) GetAccountV3Users(orgID string, q models.UserV3Query) (models.Users, error) {
-	response := models.Users{}
+	users := models.Users{}
 
-	// Add shit here
+	if orgID == "empty" {
+		return users, nil
+	}
 
-	return response, nil
+	if orgID == "errorTest" {
+		return users, fmt.Errorf("error retrieving V3 Users")
+	}
+
+	displayNameNum, err := rand.Int(rand.Reader, big.NewInt(99-0))
+	if err != nil {
+		return users, err
+	}
+
+	users.AddUser(models.User{
+		Username:      "TestUser" + strconv.Itoa(int(displayNameNum.Int64())),
+		ID:            uuid.New().String(),
+		Email:         "lub@dub.com",
+		FirstName:     "test",
+		LastName:      "case",
+		AddressString: "https://usersTest.com",
+		IsActive:      true,
+		IsInternal:    true,
+		Locale:        "en_US",
+		OrgID:         orgID,
+		DisplayName:   "FedRAMP" + strconv.Itoa(int(displayNameNum.Int64())),
+		Type:          "User",
+	})
+
+	return users, nil
 }
 
 func (ocm *SDKMock) CloseSdkConnection() {

--- a/internal/service/ocm/ocm_mock.go
+++ b/internal/service/ocm/ocm_mock.go
@@ -90,25 +90,27 @@ func (ocm *SDKMock) GetAccountV3Users(orgID string, q models.UserV3Query) (model
 		return users, fmt.Errorf("error retrieving V3 Users")
 	}
 
-	displayNameNum, err := rand.Int(rand.Reader, big.NewInt(99-0))
-	if err != nil {
-		return users, err
-	}
+	for i := q.Offset; i < q.Limit; i++ {
+		displayNameNum, err := rand.Int(rand.Reader, big.NewInt(99-0))
+		if err != nil {
+			return users, err
+		}
 
-	users.AddUser(models.User{
-		Username:      "TestUser" + strconv.Itoa(int(displayNameNum.Int64())),
-		ID:            uuid.New().String(),
-		Email:         "lub@dub.com",
-		FirstName:     "test",
-		LastName:      "case",
-		AddressString: "https://usersTest.com",
-		IsActive:      true,
-		IsInternal:    true,
-		Locale:        "en_US",
-		OrgID:         orgID,
-		DisplayName:   "FedRAMP" + strconv.Itoa(int(displayNameNum.Int64())),
-		Type:          "User",
-	})
+		users.AddUser(models.User{
+			Username:      "TestUser" + strconv.Itoa(int(displayNameNum.Int64())),
+			ID:            uuid.New().String(),
+			Email:         "lub@dub.com",
+			FirstName:     "test",
+			LastName:      "case",
+			AddressString: "https://usersTest.com",
+			IsActive:      true,
+			IsInternal:    true,
+			Locale:        "en_US",
+			OrgID:         orgID,
+			DisplayName:   "FedRAMP" + strconv.Itoa(int(displayNameNum.Int64())),
+			Type:          "User",
+		})
+	}
 
 	return users, nil
 }

--- a/internal/service/ocm/ocm_mock.go
+++ b/internal/service/ocm/ocm_mock.go
@@ -17,7 +17,7 @@ func (ocm *SDKMock) InitSdkConnection(ctx context.Context) error {
 	return nil
 }
 
-func (ocm *SDKMock) GetUsers(u models.UserBody, q models.UserQuery) (models.Users, error) {
+func (ocm *SDKMock) GetUsers(u models.UserBody, q models.UserV1Query) (models.Users, error) {
 	var users models.Users
 
 	if u.Users == nil {
@@ -75,6 +75,14 @@ func (ocm *SDKMock) GetOrgAdmin(users []models.User) (models.OrgAdminResponse, e
 			IsOrgAdmin: true,
 		}
 	}
+
+	return response, nil
+}
+
+func (ocm *SDKMock) GetAccountV3Users(orgID string, q models.UserV3Query) (models.Users, error) {
+	response := models.Users{}
+
+	// Add shit here
 
 	return response, nil
 }


### PR DESCRIPTION
Add logic creating the accounts/v3/<org_id>/users endpoint.

Much like the **/users** endpoint before it, the v3/users endpoint reaches out to the AMS API and gathers the user data, searching with the query on Org_id.  This is an explicit search on the Org_ID itself.

Additionally I added mock logic to the accounts/v3/<org_id>/users endpoint which allows for a user (after launching the service with USERS_MODULE=mock) to input any org_id into the request URL and it will return mocked user data.