### PR TITLE
[/sendEmails] translate usernames -> emails when sending emails as necessary

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -59,13 +59,19 @@ objects:
             valueFrom:
               secretKeyRef:
                 name: aws-ses
-                key: access-key
+                key: aws_access_key_id
                 optional: true
           - name: SES_SECRET_KEY
             valueFrom:
               secretKeyRef:
                 name: aws-ses
-                key: secret-key
+                key: aws_secret_access_key
+                optional: true
+          - name: SES_REGION
+            valueFrom:
+              secretKeyRef:
+                name: aws-ses
+                key: aws_region
                 optional: true
           - name: MAILER_MODULE
             value: "${MAILER_MODULE}"

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/redhatinsights/platform-go-middlewares v0.20.1-0.20230119152702-e3779317d1aa
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/zap v1.21.0
+	golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1322,6 +1322,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb h1:PaBZQdo+iSDyHT053FjUCgZQ/9uqVwPOcl7KSWhKn6w=
+golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,10 @@ import (
 )
 
 type MbopConfig struct {
+	FromEmail              string
+	SESRegion              string
+	SESAccessKey           string
+	SESSecretKey           string
 	MailerModule           string
 	JwtModule              string
 	JwkURL                 string
@@ -46,6 +50,10 @@ func Get() *MbopConfig {
 		JwtModule:       fetchWithDefault("JWT_MODULE", ""),
 		JwkURL:          fetchWithDefault("JWK_URL", ""),
 		MailerModule:    fetchWithDefault("MAILER_MODULE", "print"),
+		FromEmail:       fetchWithDefault("FROM_EMAIL", "no-reply@redhat.com"),
+		SESRegion:       fetchWithDefault("SES_REGION", "us-east-1"),
+		SESAccessKey:    fetchWithDefault("SES_ACCESS_KEY", ""),
+		SESSecretKey:    fetchWithDefault("SES_SECRET_KEY", ""),
 		DisableCatchall: disableCatchAll,
 
 		DatabaseHost:     fetchWithDefault("DATABASE_HOST", "localhost"),

--- a/internal/handlers/constants.go
+++ b/internal/handlers/constants.go
@@ -7,6 +7,7 @@ Constants used throughout the handlers package, will probably mostly be module d
 const awsModule = "aws"
 const amsModule = "ams"
 const mockModule = "mock"
+const printModule = "print"
 
 const defaultLimit = 100
 const defaultOffset = 0

--- a/internal/service/mailer/helpers.go
+++ b/internal/service/mailer/helpers.go
@@ -1,0 +1,92 @@
+package mailer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/redhatinsights/mbop/internal/config"
+	l "github.com/redhatinsights/mbop/internal/logger"
+	"github.com/redhatinsights/mbop/internal/models"
+	"github.com/redhatinsights/mbop/internal/service/ocm"
+	"golang.org/x/exp/maps"
+)
+
+func LookupEmailsForUsernames(ctx context.Context, email *models.Email) error {
+	// Generate a map of names to look up from the email to/cc/bcc
+	toLookup := make(map[string]string)
+	for _, name := range email.Recipients {
+		if !strings.Contains(name, "@") {
+			toLookup[name] = ""
+		}
+	}
+	for _, name := range email.CcList {
+		if !strings.Contains(name, "@") {
+			toLookup[name] = ""
+		}
+	}
+	for _, name := range email.BccList {
+		if !strings.Contains(name, "@") {
+			toLookup[name] = ""
+		}
+	}
+
+	// nothing to lookup
+	if len(toLookup) == 0 {
+		return nil
+	}
+
+	l.Log.Info("Looking up usernames", "user_module", config.Get().UsersModule, "usernames", maps.Keys(toLookup))
+
+	// using the appropriate AMS Module - search and look up the emails from the
+	// usernames
+	switch config.Get().UsersModule {
+	case "ams":
+		ocm, err := ocm.NewOcmClient()
+		if err != nil {
+			return err
+		}
+
+		err = ocm.InitSdkConnection(ctx)
+		if err != nil {
+			return err
+		}
+
+		users, err := ocm.GetUsers(models.UserBody{Users: maps.Keys(toLookup)}, models.UserV1Query{})
+		if err != nil {
+			return err
+		}
+
+		for _, user := range users.Users {
+			toLookup[user.Username] = user.Email
+		}
+	case "mock":
+		for k := range toLookup {
+			toLookup[k] = k + "@mocked.biz"
+		}
+	default:
+		return fmt.Errorf("no configured user module for username translations")
+	}
+
+	// ...and finally, replace the usernames -> in the lists on the email objects
+	for i, name := range email.Recipients {
+		if _, ok := toLookup[name]; ok {
+			email.Recipients = append(email.Recipients[:i], toLookup[name])
+			email.Recipients = append(email.Recipients, email.Recipients[i+1:]...)
+		}
+	}
+	for i, name := range email.CcList {
+		if _, ok := toLookup[name]; ok {
+			email.CcList = append(email.CcList[:i], toLookup[name])
+			email.CcList = append(email.CcList, email.CcList[i+1:]...)
+		}
+	}
+	for i, name := range email.BccList {
+		if _, ok := toLookup[name]; ok {
+			email.BccList = append(email.BccList[:i], toLookup[name])
+			email.BccList = append(email.BccList, email.BccList[i+1:]...)
+		}
+	}
+
+	return nil
+}

--- a/internal/service/mailer/helpers_test.go
+++ b/internal/service/mailer/helpers_test.go
@@ -1,0 +1,52 @@
+package mailer
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/redhatinsights/mbop/internal/config"
+	"github.com/redhatinsights/mbop/internal/logger"
+	"github.com/redhatinsights/mbop/internal/models"
+	"github.com/stretchr/testify/suite"
+)
+
+type TestSuite struct {
+	suite.Suite
+}
+
+func TestSuiteRun(t *testing.T) {
+	suite.Run(t, new(TestSuite))
+}
+
+func (suite *TestSuite) SetupSuite() {
+	config.Reset()
+	os.Setenv("MAILER_MODULE", "print")
+	os.Setenv("USERS_MODULE", "mock")
+
+	_ = logger.Init()
+}
+
+func (suite *TestSuite) TestMockConversionAll() {
+	email := models.Email{
+		Recipients: []string{"me"},
+		CcList:     []string{"you"},
+		BccList:    []string{"everyone"},
+	}
+	err := LookupEmailsForUsernames(context.Background(), &email)
+	suite.Nil(err)
+	suite.Equal("me@mocked.biz", email.Recipients[0])
+	suite.Equal("you@mocked.biz", email.CcList[0])
+	suite.Equal("everyone@mocked.biz", email.BccList[0])
+}
+
+func (suite *TestSuite) TestMockConversionSome() {
+	email := models.Email{
+		Recipients: []string{"me"},
+		CcList:     []string{"you@gmail.com"},
+	}
+	err := LookupEmailsForUsernames(context.Background(), &email)
+	suite.Nil(err)
+	suite.Equal("me@mocked.biz", email.Recipients[0])
+	suite.Equal("you@gmail.com", email.CcList[0])
+}


### PR DESCRIPTION
This reaches out to the configured `#{USERS_MODULE}` and converts anything that doesn't look like an email (it looks like notifications just puts the username in when sending emails) to the email pretending its a username. 

Right now there are 2 supported modules: 
- `ams` which makes sense
- `mock` which just appends `@mocked.biz` to the usernames that need it. 