### PR TITLE
Add registration token endpoint

### DIFF
--- a/cmd/mbop/mbop.go
+++ b/cmd/mbop/mbop.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/redhatinsights/mbop/internal/service/mailer"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/redhatinsights/mbop/internal/handlers"
@@ -38,6 +39,7 @@ func main() {
 	r.Post("/v1/sendEmails", handlers.SendEmails)
 	r.Get("/v3/accounts/{orgID}/users", handlers.AccountsV3UsersHandler)
 	r.Post("/v3/accounts/{orgID}/usersBy", handlers.AccountsV3UsersByHandler)
+	r.With(identity.EnforceIdentity).Get("/v1/registrations/token", handlers.TokenHandler)
 
 	err := mailer.InitConfig()
 	if err != nil {

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -99,6 +99,26 @@ objects:
                 name: mbop-db
                 key: db.name
                 optional: true
+          - name: TOKEN_PRIVATE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: rsa-token-gen
+                key: private-key
+                optional: true
+          - name: TOKEN_PUBLIC_KEY
+            valueFrom:
+              secretKeyRef:
+                name: rsa-token-gen
+                key: public-key
+                optional: true
+          - name: TOKEN_KID
+            valueFrom:
+              secretKeyRef:
+                name: rsa-token-gen
+                key: kid
+                optional: true
+          - name: TOKEN_TTL_DURATION
+            value: ${TOKEN_TTL_DURATION}
           - name: STORE_BACKEND
             value: ${STORE_BACKEND}
           image: quay.io/cloudservices/mbop:${IMAGE_TAG}
@@ -188,3 +208,6 @@ parameters:
 - name: STORE_BACKEND
   description: which store to use for satellite registrations
   value: "memory"
+- name: TOKEN_TTL_DURATION
+  description: duration string (30s, 5m, 1h, etc) for token TTL
+  value: ""

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
 	github.com/goccy/go-json v0.10.0 // indirect
 	github.com/golang-jwt/jwt/v4 v4.4.1 // indirect
+	github.com/golang-jwt/jwt/v5 v5.0.0-rc.1 // indirect
 	github.com/golang/glog v1.0.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.3.0 // indirect
@@ -69,6 +70,7 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/redhatinsights/platform-go-middlewares v0.20.1-0.20230119152702-e3779317d1aa // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,7 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.17.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.38.51/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go-v2 v1.8.0/go.mod h1:xEFuWz+3TYdlPRuo+CqATbeDWIWyaT5uAPwPaWtgse0=
 github.com/aws/aws-sdk-go-v2 v1.9.2/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
 github.com/aws/aws-sdk-go-v2 v1.17.3 h1:shN7NlnVzvDUgPQ+1rLMSxY8OWRNDRYtiqe0p/PgrhY=
@@ -453,6 +454,7 @@ github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYis
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-chi/chi/v5 v5.0.8 h1:lD+NLqFcAi1ovnVZpsnObHGW4xb4J8lNmoYVfECH1Y0=
 github.com/go-chi/chi/v5 v5.0.8/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=
@@ -550,6 +552,8 @@ github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzw
 github.com/golang-jwt/jwt/v4 v4.1.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.4.1 h1:pC5DB52sCeK48Wlb9oPcdhnjkz1TKt1D/P7WKJ0kUcQ=
 github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.0.0-rc.1 h1:tDQ1LjKga657layZ4JLsRdxgvupebc0xuPwRNuTfUgs=
+github.com/golang-jwt/jwt/v5 v5.0.0-rc.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang-migrate/migrate/v4 v4.15.2 h1:vU+M05vs6jWHKDdmE1Ecwj0BznygFc4QsdRe2E/L7kc=
 github.com/golang-migrate/migrate/v4 v4.15.2/go.mod h1:f2toGLkYqD3JH+Todi4aZ2ZdbeUNx4sIwiOK96rE9Lw=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
@@ -1078,6 +1082,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/redhatinsights/platform-go-middlewares v0.20.1-0.20230119152702-e3779317d1aa h1:noqA6UChsLTI+OQzWzzc+ASnAKb3RYlUfMHiJmY2rjM=
+github.com/redhatinsights/platform-go-middlewares v0.20.1-0.20230119152702-e3779317d1aa/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ type MbopConfig struct {
 	OauthTokenURL          string
 	AmsURL                 string
 	TokenTTL               string
+	TokenKID               string
 	PrivateKey             string
 	PublicKey              string
 
@@ -50,6 +51,7 @@ func Get() *MbopConfig {
 		OauthTokenURL:          fetchWithDefault("OAUTH_TOKEN_URL", ""),
 		AmsURL:                 fetchWithDefault("AMS_URL", ""),
 		TokenTTL:               fetchWithDefault("TOKEN_TTL_DURATION", "5m"),
+		TokenKID:               fetchWithDefault("TOKEN_KID", ""),
 		PrivateKey:             fetchWithDefault("TOKEN_PRIVATE_KEY", ""),
 		PublicKey:              fetchWithDefault("TOKEN_PUBLIC_KEY", ""),
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,9 @@ type MbopConfig struct {
 	CognitoScope           string
 	OauthTokenURL          string
 	AmsURL                 string
+	TokenTTL               string
+	PrivateKey             string
+	PublicKey              string
 
 	StoreBackend     string
 	DatabaseHost     string
@@ -46,6 +49,9 @@ func Get() *MbopConfig {
 		CognitoScope:           fetchWithDefault("COGNITO_SCOPE", ""),
 		OauthTokenURL:          fetchWithDefault("OAUTH_TOKEN_URL", ""),
 		AmsURL:                 fetchWithDefault("AMS_URL", ""),
+		TokenTTL:               fetchWithDefault("TOKEN_TTL_DURATION", "5m"),
+		PrivateKey:             fetchWithDefault("TOKEN_PRIVATE_KEY", ""),
+		PublicKey:              fetchWithDefault("TOKEN_PUBLIC_KEY", ""),
 	}
 
 	conf = c

--- a/internal/handlers/token_handler.go
+++ b/internal/handlers/token_handler.go
@@ -1,0 +1,45 @@
+package handlers
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/redhatinsights/mbop/internal/config"
+	l "github.com/redhatinsights/mbop/internal/logger"
+	"github.com/redhatinsights/mbop/internal/models"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+)
+
+type TokenResp struct {
+	Token string `json:"token"`
+}
+
+func TokenHandler(w http.ResponseWriter, r *http.Request) {
+	xrhid := identity.Get(r.Context()).Identity
+	if xrhid.OrgID == "" {
+		do400(w, "Missing org_id in x-rh-identity")
+		return
+	}
+
+	if xrhid.User.Username == "" {
+		do400(w, "Missing username in x-rh-identity")
+		return
+	}
+
+	c := config.Get()
+	privateKey := []byte(c.PrivateKey)
+	pubKey := []byte(c.PublicKey)
+
+	token := models.Token{PrivateKey: privateKey, PublicKey: pubKey}
+	ttl, err := time.ParseDuration(c.TokenTTL)
+	if err != nil {
+		l.Log.Error(err, "Error setting TTL")
+	}
+
+	newToken, err := token.Create(ttl, xrhid)
+	if err != nil {
+		l.Log.Error(err, "Error creating token")
+	}
+
+	sendJSON(w, TokenResp{Token: newToken})
+}

--- a/internal/models/token.go
+++ b/internal/models/token.go
@@ -1,0 +1,39 @@
+package models
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/redhatinsights/mbop/internal/config"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+)
+
+type Token struct {
+	PublicKey  []byte `json:"public_key"`
+	PrivateKey []byte `json:"private_key"`
+}
+
+func (t Token) Create(ttl time.Duration, xrhid identity.Identity) (string, error) {
+	key, err := jwt.ParseRSAPrivateKeyFromPEM(t.PrivateKey)
+	if err != nil {
+		fmt.Println(string(t.PrivateKey))
+		return "", fmt.Errorf("Failed to parse key: %w", err)
+	}
+
+	now := time.Now().UTC()
+	claims := make(jwt.MapClaims)
+	claims["exp"] = now.Add(ttl).Unix()
+	claims["iat"] = now.Unix()
+	claims["nbf"] = now.Unix()
+	claims["kid"] = config.Get().TokenKID
+	claims["org_id"] = xrhid.OrgID
+	claims["username"] = xrhid.User.Username
+
+	token, err := jwt.NewWithClaims(jwt.SigningMethodRS256, claims).SignedString(key)
+	if err != nil {
+		return "", fmt.Errorf("Failed to sign token: %w", err)
+	}
+
+	return token, nil
+}


### PR DESCRIPTION
[Add dependencies for identity middleware and jwt](https://github.com/RedHatInsights/mbop/commit/f4b56cd8c6f1c94c955d8cdb6fdee06127454e17)

----

[Add config for RSA TTL and keys](https://github.com/RedHatInsights/mbop/commit/a29fb55eeec36670579121349f5f7be654b84872) 

Expects the following env vars:
```
TOKEN_PRIVATE_KEY # RSA private key for signing JWTs
TOKEN_PUBLIC_KEY # RSA public key for signing JWTs
TOKEN_TTL_DURATION # TTL duration for JWT expiration
TOKEN_KID # kid of the tokens when signed
```

The environment variables will be pulled in via a secret in the template, and
surfaced via the config module.

----

[Add /v1/registrations/token route](https://github.com/RedHatInsights/mbop/commit/545880fa25004fc58a52e40a3e42105e830a8c16) 

This will call the token handler after enforcing the presence of the `x-rh-identity`
header on the request.

----

[Add token signing and handler](https://github.com/RedHatInsights/mbop/commit/704cfe24dfb7fb4775c9faa1b398737fde4f39ca) 

Creates a token model which can create a JWT provided a TTL and identity object
from an `x-rh-identity` header.

The `Create` method will parse the private key, build the following claims:

```
exp - expiration of the token
iat - time the token was issued
nbf - time the token is not good before
kid - identifier for JWK (may not be required)
org_id - from the identity
username - from the identity
```

Those claims are then signed with the private key. We may not explicitly need
to use the public key for this, but we'll either need to surface the public key
for the gateway to consume via an endpoint, or secret.

This also sets up the handler, which will service `/v1/registrations/token` GET
requests.

We'll enforce the `x-rh-identity` exists, as well as `org_id` and `username` as
we'll need those for the token.

We create a new token object with the pub/private keys, set the TTL, and pass the
identity and TTL into the `Create` method, handling errors before returning a
token payload like:

```
{"token": <token>}
```

----

**Local Testing:**
- setup a private/public RSA key pair
- export the env vars from above (including your key pair)
- run a GET against `/v1/registrations/token` with the `x-rh-identity: <base64encoded>` header
- you should now have a token which you can verify against your pub key