### PR TITLE
Removing Base Image Tags within Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18.4-8 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -13,7 +13,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build ./cmd/mbop/mbop.go
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-923
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /
 COPY --from=builder /workspace/mbop .
 USER 65532:65532


### PR DESCRIPTION
This PR is to remove the Image Tags for the Base Images used within the Dockerfile. 

This is to:
- Ensure that we are using the latest Go-Toolset RPMs during the creation of the Go Binary 
- Ensure that we are pulling the latest RPMs for ubi8/ubi-minimal