### PR TITLE
use older pg syntax for triggers/functions and uuid generation

### DIFF
--- a/internal/store/migrations/0_initial.up.sql
+++ b/internal/store/migrations/0_initial.up.sql
@@ -1,6 +1,9 @@
+-- so we can generate random uuids.
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
 create table if not exists public.registrations
 (
-    id     uuid  default gen_random_uuid() not null
+    id     uuid  default uuid_generate_v4() not null
         constraint registrations_pk
             primary key,
     org_id varchar                         not null,
@@ -15,7 +18,7 @@ create unique index if not exists registrations_org_id_uid_uindex
     on public.registrations (org_id, uid);
 
 -- auto-update the `updated_at` column on update
-create or replace function
+create function
     update_updated_at()
     returns trigger language plpgsql as $$
 begin
@@ -24,6 +27,6 @@ begin
 end;
 $$;
 
-create or replace trigger registration_updated
+create trigger registration_updated
     before update on public.registrations
     for each row execute function update_updated_at();


### PR DESCRIPTION
turns out running pg 14 all the time when other places are using 13 or 12 isn't the best for raw sql stuff. 