### PR TITLE
Add DELETE /v1/registrations endpoint

### DIFF
--- a/cmd/mbop/mbop.go
+++ b/cmd/mbop/mbop.go
@@ -39,8 +39,13 @@ func main() {
 	r.Post("/v1/sendEmails", handlers.SendEmails)
 	r.Get("/v3/accounts/{orgID}/users", handlers.AccountsV3UsersHandler)
 	r.Post("/v3/accounts/{orgID}/usersBy", handlers.AccountsV3UsersByHandler)
-	r.With(identity.EnforceIdentity).Post("/v1/registrations", handlers.RegistrationHandler)
-	r.With(identity.EnforceIdentity).Get("/v1/registrations/token", handlers.TokenHandler)
+
+	// all the handlers that need xrhid
+	r.With(identity.EnforceIdentity).Group(func(r chi.Router) {
+		r.Post("/v1/registrations", handlers.RegistrationCreateHandler)
+		r.Delete("/v1/registrations/{uid}", handlers.RegistrationDeleteHandler)
+		r.Get("/v1/registrations/token", handlers.TokenHandler)
+	})
 
 	err := mailer.InitConfig()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.0.0-rc.1
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/google/uuid v1.3.0
+	github.com/jackc/pgconn v1.12.0
 	github.com/openshift-online/ocm-sdk-go v0.1.311
 	github.com/pkg/errors v0.9.1
 	github.com/redhatinsights/platform-go-middlewares v0.20.1-0.20230119152702-e3779317d1aa
@@ -46,7 +47,6 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
-	github.com/jackc/pgconn v1.12.0 // indirect
 	github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/internal/handlers/registration_handler.go
+++ b/internal/handlers/registration_handler.go
@@ -82,18 +82,6 @@ func RegistrationDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		do400(w, "invalid uid passed in path")
 	}
 
-	gatewayCN := r.Header.Get("x-rh-certauth-cn")
-	parts := strings.Split(gatewayCN, "=")
-	if gatewayCN == "" || len(parts) < 2 {
-		do400(w, "[x-rh-certauth-cn] header not present")
-		return
-	}
-
-	if parts[1] != uid {
-		do400(w, "x-rh-certauth-cn does not match uid")
-		return
-	}
-
 	id := identity.Get(r.Context())
 	if !id.Identity.User.OrgAdmin {
 		doError(w, "user must be org admin to register satellite", 403)

--- a/internal/handlers/registration_handler.go
+++ b/internal/handlers/registration_handler.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/redhatinsights/mbop/internal/store"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
@@ -15,7 +16,7 @@ type registationCreateRequest struct {
 	UID *string `json:"uid,omitempty"`
 }
 
-func RegistrationHandler(w http.ResponseWriter, r *http.Request) {
+func RegistrationCreateHandler(w http.ResponseWriter, r *http.Request) {
 	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		do500(w, "failed to read body bytes: "+err.Error())
@@ -64,7 +65,7 @@ func RegistrationHandler(w http.ResponseWriter, r *http.Request) {
 		UID:   *body.UID,
 	})
 	if err != nil {
-		if errors.Is(store.ErrUIDAlreadyExists, err) {
+		if errors.Is(err, store.ErrUIDAlreadyExists) {
 			doError(w, "existing registration found", 409)
 		} else {
 			do500(w, "failed to create registration: "+err.Error())
@@ -73,4 +74,43 @@ func RegistrationHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sendJSONWithStatusCode(w, newResponse("Successfully registered"), 201)
+}
+
+func RegistrationDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	uid := chi.URLParam(r, "uid")
+	if uid == "" {
+		do400(w, "invalid uid passed in path")
+	}
+
+	gatewayCN := r.Header.Get("x-rh-certauth-cn")
+	parts := strings.Split(gatewayCN, "=")
+	if gatewayCN == "" || len(parts) < 2 {
+		do400(w, "[x-rh-certauth-cn] header not present")
+		return
+	}
+
+	if parts[1] != uid {
+		do400(w, "x-rh-certauth-cn does not match uid")
+		return
+	}
+
+	id := identity.Get(r.Context())
+	if !id.Identity.User.OrgAdmin {
+		doError(w, "user must be org admin to register satellite", 403)
+		return
+	}
+
+	db := store.GetStore()
+
+	err := db.Delete(id.Identity.OrgID, uid)
+	if err != nil {
+		if errors.Is(err, store.ErrRegistrationNotFound) {
+			do404(w, err.Error())
+		} else {
+			do500(w, "error deleting registration: "+err.Error())
+		}
+		return
+	}
+
+	sendJSONWithStatusCode(w, newResponse("Successfully de-registered"), 204)
 }

--- a/internal/handlers/registration_handler_test.go
+++ b/internal/handlers/registration_handler_test.go
@@ -199,47 +199,6 @@ func (suite *RegistrationTestSuite) TestSuccessfulRegistrationDelete() {
 	suite.Equal(http.StatusNoContent, suite.rec.Result().StatusCode)
 }
 
-func (suite *RegistrationTestSuite) TestNotMatchingCNDelete() {
-	_, err := suite.store.Create(&store.Registration{UID: "abc1234", OrgID: "1234"})
-	suite.Nil(err)
-
-	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("uid", "abc1234")
-
-	req := httptest.NewRequest(http.MethodDelete, "http://foobar/registrations/{uid}", nil)
-	req = req.WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{Identity: identity.Identity{
-		User:  identity.User{OrgAdmin: true},
-		OrgID: "1234",
-	}}))
-	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-	req.Header.Set("x-rh-certauth-cn", "/CN=abc12345")
-
-	RegistrationDeleteHandler(suite.rec, req)
-
-	//nolint:bodyclose
-	suite.Equal(http.StatusBadRequest, suite.rec.Result().StatusCode)
-}
-
-func (suite *RegistrationTestSuite) TestNoCNDelete() {
-	_, err := suite.store.Create(&store.Registration{UID: "abc1234", OrgID: "1234"})
-	suite.Nil(err)
-
-	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("uid", "abc1234")
-
-	req := httptest.NewRequest(http.MethodDelete, "http://foobar/registrations/{uid}", nil)
-	req = req.WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{Identity: identity.Identity{
-		User:  identity.User{OrgAdmin: true},
-		OrgID: "1234",
-	}}))
-	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-
-	RegistrationDeleteHandler(suite.rec, req)
-
-	//nolint:bodyclose
-	suite.Equal(http.StatusBadRequest, suite.rec.Result().StatusCode)
-}
-
 func (suite *RegistrationTestSuite) TestNotOrgAdminDelete() {
 	_, err := suite.store.Create(&store.Registration{UID: "abc1234", OrgID: "1234"})
 	suite.Nil(err)

--- a/internal/store/in_memory_store_impl.go
+++ b/internal/store/in_memory_store_impl.go
@@ -55,5 +55,5 @@ func (m *inMemoryStore) Delete(orgID string, uid string) error {
 		}
 	}
 
-	return errors.New("failed to find registration")
+	return ErrRegistrationNotFound
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -18,6 +18,7 @@ var mem Store
 var (
 	ErrRegistrationAlreadyExists = errors.New("registration already exists")
 	ErrUIDAlreadyExists          = errors.New("uid already exists")
+	ErrRegistrationNotFound      = errors.New("registration not found")
 )
 
 func SetupStore() error {


### PR DESCRIPTION
Title is self explanatory.

Notable changes:
- Moved all the xrhid handlers into their own group so we only have to enforce identity once
- Updated uid conflict handling to return our error rather than the generic pgx driver error