### PR TITLE
Add ability to disable catchall handler

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -121,6 +121,8 @@ objects:
             value: ${TOKEN_TTL_DURATION}
           - name: STORE_BACKEND
             value: ${STORE_BACKEND}
+          - name: DISABLE_CATCHALL
+            value: ${DISABLE_CATCHALL}
           image: quay.io/cloudservices/mbop:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           name: mbop
@@ -211,3 +213,6 @@ parameters:
 - name: TOKEN_TTL_DURATION
   description: duration string (30s, 5m, 1h, etc) for token TTL
   value: ""
+- name: DISABLE_CATCHALL
+  description: disable fallthrough to catchall handler
+  value: "false"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,9 @@
 package config
 
-import "os"
+import (
+	"os"
+	"strconv"
+)
 
 type MbopConfig struct {
 	MailerModule           string
@@ -16,6 +19,7 @@ type MbopConfig struct {
 	TokenKID               string
 	PrivateKey             string
 	PublicKey              string
+	DisableCatchall        bool
 
 	StoreBackend     string
 	DatabaseHost     string
@@ -32,11 +36,14 @@ func Get() *MbopConfig {
 		return conf
 	}
 
+	disableCatchAll, _ := strconv.ParseBool(fetchWithDefault("DISABLE_CATCHALL", "false"))
+
 	c := &MbopConfig{
-		UsersModule:  fetchWithDefault("USERS_MODULE", ""),
-		JwtModule:    fetchWithDefault("JWT_MODULE", ""),
-		JwkURL:       fetchWithDefault("JWK_URL", ""),
-		MailerModule: fetchWithDefault("MAILER_MODULE", "print"),
+		UsersModule:     fetchWithDefault("USERS_MODULE", ""),
+		JwtModule:       fetchWithDefault("JWT_MODULE", ""),
+		JwkURL:          fetchWithDefault("JWK_URL", ""),
+		MailerModule:    fetchWithDefault("MAILER_MODULE", "print"),
+		DisableCatchall: disableCatchAll,
 
 		DatabaseHost:     fetchWithDefault("DATABASE_HOST", "localhost"),
 		DatabasePort:     fetchWithDefault("DATABASE_PORT", "5432"),

--- a/internal/handlers/catchall.go
+++ b/internal/handlers/catchall.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 
+	"github.com/redhatinsights/mbop/internal/config"
 	"github.com/redhatinsights/mbop/internal/service/catchall"
 )
 
@@ -10,5 +11,10 @@ import (
 var mbop = catchall.MakeNewMBOPServer()
 
 func CatchAll(w http.ResponseWriter, r *http.Request) {
+	if config.Get().DisableCatchall {
+		do404(w, "not found")
+		return
+	}
+
 	mbop.MainHandler(w, r)
 }


### PR DESCRIPTION
Bit us a few times so far - this should make it easier to track when an endpoint doesn't actually get handled by us explicitly. 