### PR TITLE
Add `is_org_admin` claim to the registration token

### DIFF
--- a/internal/models/token.go
+++ b/internal/models/token.go
@@ -29,6 +29,7 @@ func (t Token) Create(ttl time.Duration, xrhid identity.Identity) (string, error
 	claims["kid"] = config.Get().TokenKID
 	claims["org_id"] = xrhid.OrgID
 	claims["username"] = xrhid.User.Username
+	claims["is_org_admin"] = xrhid.User.OrgAdmin
 
 	token, err := jwt.NewWithClaims(jwt.SigningMethodRS256, claims).SignedString(key)
 	if err != nil {


### PR DESCRIPTION
This ensures the a token issued for registration will have the `is_org_admin` flag from the `x-rh-identity` header so that the check durin registration [1] can consume this claim.

[1] https://github.com/RedHatInsights/mbop/blob/master/internal/handlers/registration_handler.go#L38