### PR TITLE
Change 404 -> 401 when a registration isn't found on /v1/auth

### DIFF
--- a/internal/handlers/auth_v1_handler.go
+++ b/internal/handlers/auth_v1_handler.go
@@ -42,7 +42,7 @@ func AuthV1Handler(w http.ResponseWriter, r *http.Request) {
 	reg, err := db.FindByUID(gatewayCN)
 	if err != nil {
 		if errors.Is(err, store.ErrRegistrationNotFound) {
-			do404(w, err.Error())
+			doError(w, err.Error(), 401)
 		} else {
 			do500(w, "failed to search for registration: "+err.Error())
 		}

--- a/internal/handlers/auth_v1_handler_test.go
+++ b/internal/handlers/auth_v1_handler_test.go
@@ -44,7 +44,7 @@ func (suite *AuthV1TestSuite) TestV1AuthNotFound() {
 	AuthV1Handler(suite.rec, req)
 
 	//nolint:bodyclose
-	suite.Equal(http.StatusNotFound, suite.rec.Result().StatusCode)
+	suite.Equal(http.StatusUnauthorized, suite.rec.Result().StatusCode)
 }
 
 func (suite *AuthV1TestSuite) TestV1AuthSuccess() {


### PR DESCRIPTION
For feature parity with commercial BOP. 