### PR TITLE
Is internal

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -123,6 +123,8 @@ objects:
             value: ${STORE_BACKEND}
           - name: DISABLE_CATCHALL
             value: ${DISABLE_CATCHALL}
+          - name: IS_INTERNAL_LABEL
+            value: ${IS_INTERNAL_LABEL}
           image: quay.io/cloudservices/mbop:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           name: mbop
@@ -216,3 +218,6 @@ parameters:
 - name: DISABLE_CATCHALL
   description: disable fallthrough to catchall handler
   value: "false"
+- name: IS_INTERNAL_LABEL
+  description: OCM label to inform whether or not an account is internal
+  value: ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type MbopConfig struct {
 	PrivateKey             string
 	PublicKey              string
 	DisableCatchall        bool
+	IsInternalLabel        string
 
 	StoreBackend     string
 	DatabaseHost     string
@@ -61,6 +62,7 @@ func Get() *MbopConfig {
 		TokenKID:               fetchWithDefault("TOKEN_KID", ""),
 		PrivateKey:             fetchWithDefault("TOKEN_PRIVATE_KEY", ""),
 		PublicKey:              fetchWithDefault("TOKEN_PUBLIC_KEY", ""),
+		IsInternalLabel:        fetchWithDefault("IS_INTERNAL_LABEL", ""),
 	}
 
 	conf = c

--- a/internal/service/ocm/ocm_impl.go
+++ b/internal/service/ocm/ocm_impl.go
@@ -144,6 +144,16 @@ func (ocm *SDK) CloseSdkConnection() {
 	ocm.client.Close()
 }
 
+func getIsInternal(user *v1.Account) bool {
+	labels := user.Labels()
+	for _, l := range labels {
+		if l.Value() == config.Get().IsInternalLabel {
+			return true
+		}
+	}
+	return false
+}
+
 func responseToUsers(response *v1.AccountsListResponse) models.Users {
 	users := models.Users{}
 	items := response.Items().Slice()
@@ -157,7 +167,7 @@ func responseToUsers(response *v1.AccountsListResponse) models.Users {
 			LastName:      items[i].LastName(),
 			AddressString: items[i].HREF(),
 			IsActive:      true,
-			IsInternal:    false,
+			IsInternal:    getIsInternal(items[i]),
 			Locale:        "en_US",
 			OrgID:         items[i].Organization().ID(),
 			DisplayName:   items[i].Organization().Name(),

--- a/internal/service/ocm/ocm_impl_test.go
+++ b/internal/service/ocm/ocm_impl_test.go
@@ -13,11 +13,11 @@ import (
 
 type TestSuite struct {
 	suite.Suite
-	is_internal_label string
+	IsInternalLabel string
 }
 
 func (suite *TestSuite) SetupSuite() {
-	suite.is_internal_label = "foo"
+	suite.IsInternalLabel = "foo"
 }
 
 func (suite *TestSuite) SetupTest() {
@@ -27,7 +27,7 @@ func (suite *TestSuite) SetupTest() {
 func (suite *TestSuite) TestGetIsInternalMatch() {
 	os.Setenv("IS_INTERNAL_LABEL", "foo")
 	l := &v1.LabelBuilder{}
-	l.Value(suite.is_internal_label)
+	l.Value(suite.IsInternalLabel)
 	acctB := &v1.AccountBuilder{}
 	acctB.Labels(l)
 	acct, _ := acctB.Build()
@@ -44,7 +44,7 @@ func (suite *TestSuite) TestGetIsInternaEmptyLabels() {
 func (suite *TestSuite) TestGetIsInternalNoMatch() {
 	os.Setenv("IS_INTERNAL_LABEL", "bar")
 	l := &v1.LabelBuilder{}
-	l.Value(suite.is_internal_label)
+	l.Value(suite.IsInternalLabel)
 	acctB := &v1.AccountBuilder{}
 	acctB.Labels(l)
 	acct, _ := acctB.Build()

--- a/internal/service/ocm/ocm_impl_test.go
+++ b/internal/service/ocm/ocm_impl_test.go
@@ -1,0 +1,52 @@
+package ocm
+
+import (
+	"os"
+	"testing"
+
+	"github.com/redhatinsights/mbop/internal/config"
+
+	v1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type TestSuite struct {
+	suite.Suite
+	is_internal_label string
+}
+
+func (suite *TestSuite) SetupSuite() {
+	suite.is_internal_label = "foo"
+}
+
+func (suite *TestSuite) SetupTest() {
+	config.Reset()
+}
+
+func (suite *TestSuite) TestGetIsInternalMatch() {
+	os.Setenv("IS_INTERNAL_LABEL", "foo")
+	l := &v1.LabelBuilder{}
+	l.Value(suite.is_internal_label)
+	acctB := &v1.AccountBuilder{}
+	acctB.Labels(l)
+	acct, _ := acctB.Build()
+	assert.Equal(suite.T(), true, getIsInternal(acct))
+}
+
+func (suite *TestSuite) TestGetIsInternalNoMatch() {
+	os.Setenv("IS_INTERNAL_LABEL", "bar")
+	l := &v1.LabelBuilder{}
+	l.Value(suite.is_internal_label)
+	acctB := &v1.AccountBuilder{}
+	acctB.Labels(l)
+	acct, _ := acctB.Build()
+	assert.Equal(suite.T(), false, getIsInternal(acct))
+}
+
+func (suite *TestSuite) TearDownSuite() {
+}
+
+func TestExampleTestSuite(t *testing.T) {
+	suite.Run(t, new(TestSuite))
+}

--- a/internal/service/ocm/ocm_impl_test.go
+++ b/internal/service/ocm/ocm_impl_test.go
@@ -34,6 +34,13 @@ func (suite *TestSuite) TestGetIsInternalMatch() {
 	assert.Equal(suite.T(), true, getIsInternal(acct))
 }
 
+func (suite *TestSuite) TestGetIsInternaEmptyLabels() {
+	os.Setenv("IS_INTERNAL_LABEL", "foo")
+	acctB := &v1.AccountBuilder{}
+	acct, _ := acctB.Build()
+	assert.Equal(suite.T(), false, getIsInternal(acct))
+}
+
 func (suite *TestSuite) TestGetIsInternalNoMatch() {
 	os.Setenv("IS_INTERNAL_LABEL", "bar")
 	l := &v1.LabelBuilder{}

--- a/internal/service/ocm/ocm_impl_test.go
+++ b/internal/service/ocm/ocm_impl_test.go
@@ -7,53 +7,49 @@ import (
 	"github.com/redhatinsights/mbop/internal/config"
 
 	v1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
-type TestSuite struct {
+type OcmImplTestSuite struct {
 	suite.Suite
 	IsInternalLabel string
 }
 
-func (suite *TestSuite) SetupSuite() {
+func (suite *OcmImplTestSuite) SetupSuite() {
 	suite.IsInternalLabel = "foo"
 }
 
-func (suite *TestSuite) SetupTest() {
+func (suite *OcmImplTestSuite) SetupTest() {
 	config.Reset()
 }
 
-func (suite *TestSuite) TestGetIsInternalMatch() {
+func (suite *OcmImplTestSuite) TestGetIsInternalMatch() {
 	os.Setenv("IS_INTERNAL_LABEL", "foo")
 	l := &v1.LabelBuilder{}
 	l.Value(suite.IsInternalLabel)
 	acctB := &v1.AccountBuilder{}
 	acctB.Labels(l)
 	acct, _ := acctB.Build()
-	assert.Equal(suite.T(), true, getIsInternal(acct))
+	suite.Equal(true, getIsInternal(acct))
 }
 
-func (suite *TestSuite) TestGetIsInternaEmptyLabels() {
+func (suite *OcmImplTestSuite) TestGetIsInternaEmptyLabels() {
 	os.Setenv("IS_INTERNAL_LABEL", "foo")
 	acctB := &v1.AccountBuilder{}
 	acct, _ := acctB.Build()
-	assert.Equal(suite.T(), false, getIsInternal(acct))
+	suite.Equal(false, getIsInternal(acct))
 }
 
-func (suite *TestSuite) TestGetIsInternalNoMatch() {
+func (suite *OcmImplTestSuite) TestGetIsInternalNoMatch() {
 	os.Setenv("IS_INTERNAL_LABEL", "bar")
 	l := &v1.LabelBuilder{}
 	l.Value(suite.IsInternalLabel)
 	acctB := &v1.AccountBuilder{}
 	acctB.Labels(l)
 	acct, _ := acctB.Build()
-	assert.Equal(suite.T(), false, getIsInternal(acct))
+	suite.Equal(false, getIsInternal(acct))
 }
 
-func (suite *TestSuite) TearDownSuite() {
-}
-
-func TestExampleTestSuite(t *testing.T) {
-	suite.Run(t, new(TestSuite))
+func TestOcmImp(t *testing.T) {
+	suite.Run(t, new(OcmImplTestSuite))
 }


### PR DESCRIPTION
Adds support in the ocm `responseToUsers` method to dynamically set `is_internal` based on the `Labels()` for a given user account. If the environment variable `IS_INTERNAL_LABEL` value matches any labels for the account, we'll set them to be internal.