### PR TITLE
Fix 204 delete

### DIFF
--- a/internal/handlers/registration_handler.go
+++ b/internal/handlers/registration_handler.go
@@ -98,5 +98,5 @@ func RegistrationDeleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sendJSONWithStatusCode(w, newResponse("Successfully de-registered"), 204)
+	w.WriteHeader(204)
 }

--- a/internal/handlers/registration_handler_test.go
+++ b/internal/handlers/registration_handler_test.go
@@ -52,7 +52,6 @@ func (suite *RegistrationTestSuite) TestEmptyBodyCreate() {
 		WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{}))
 	RegistrationCreateHandler(suite.rec, req)
 
-	//nolint:bodyclose
 	status, rspBody := statusAndBodyFromReq(suite)
 	suite.Equal(http.StatusBadRequest, status)
 	suite.Equal("{\"message\":\"required parameter [uid] not found in body\"}", rspBody)
@@ -64,7 +63,6 @@ func (suite *RegistrationTestSuite) TestNoBodyCreate() {
 		WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{}))
 	RegistrationCreateHandler(suite.rec, req)
 
-	//nolint:bodyclose
 	status, rspBody := statusAndBodyFromReq(suite)
 	suite.Equal(http.StatusBadRequest, status)
 	suite.Equal("{\"message\":\"failed to unmarshal body: unexpected end of JSON input\"}", rspBody)
@@ -76,7 +74,6 @@ func (suite *RegistrationTestSuite) TestBadBodyCreate() {
 		WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{}))
 	RegistrationCreateHandler(suite.rec, req)
 
-	//nolint:bodyclose
 	status, rspBody := statusAndBodyFromReq(suite)
 	suite.Equal(http.StatusBadRequest, status)
 	suite.Equal("{\"message\":\"failed to unmarshal body: unexpected end of JSON input\"}", rspBody)
@@ -95,7 +92,6 @@ func (suite *RegistrationTestSuite) TestNotOrgAdminCreate() {
 
 	RegistrationCreateHandler(suite.rec, req)
 
-	//nolint:bodyclose
 	status, rspBody := statusAndBodyFromReq(suite)
 	suite.Equal(http.StatusForbidden, status)
 	suite.Equal("{\"message\":\"user must be org admin to register satellite\"}", rspBody)
@@ -114,7 +110,6 @@ func (suite *RegistrationTestSuite) TestNoGatewayCNCreate() {
 
 	RegistrationCreateHandler(suite.rec, req)
 
-	//nolint:bodyclose
 	status, rspBody := statusAndBodyFromReq(suite)
 	suite.Equal(http.StatusBadRequest, status)
 	suite.Equal("{\"message\":\"[x-rh-certauth-cn] header not present\"}", rspBody)
@@ -134,7 +129,6 @@ func (suite *RegistrationTestSuite) TestNotMatchingCNCreate() {
 
 	RegistrationCreateHandler(suite.rec, req)
 
-	//nolint:bodyclose
 	status, rspBody := statusAndBodyFromReq(suite)
 	suite.Equal(http.StatusForbidden, status)
 	suite.Equal("{\"message\":\"user must be org admin to register satellite\"}", rspBody)
@@ -154,7 +148,6 @@ func (suite *RegistrationTestSuite) TestExistingRegistrationCreate() {
 
 	RegistrationCreateHandler(suite.rec, req)
 
-	//nolint:bodyclose
 	status, rspBody := statusAndBodyFromReq(suite)
 	suite.Equal(http.StatusConflict, status)
 	suite.Equal("{\"message\":\"existing registration found\"}", rspBody)
@@ -174,7 +167,6 @@ func (suite *RegistrationTestSuite) TestExistingUidCreate() {
 
 	RegistrationCreateHandler(suite.rec, req)
 
-	//nolint:bodyclose
 	status, rspBody := statusAndBodyFromReq(suite)
 	suite.Equal(http.StatusConflict, status)
 	suite.Equal("{\"message\":\"existing registration found\"}", rspBody)
@@ -191,7 +183,6 @@ func (suite *RegistrationTestSuite) TestSuccessfulRegistrationCreate() {
 
 	RegistrationCreateHandler(suite.rec, req)
 
-	//nolint:bodyclose
 	status, rspBody := statusAndBodyFromReq(suite)
 	suite.Equal(http.StatusCreated, status)
 	suite.Equal("{\"message\":\"Successfully registered\"}", rspBody)
@@ -211,7 +202,6 @@ func (suite *RegistrationTestSuite) TestSuccessfulRegistrationCreateOtherUIDForm
 
 	RegistrationCreateHandler(suite.rec, req)
 
-	//nolint:bodyclose
 	status, rspBody := statusAndBodyFromReq(suite)
 	suite.Equal(http.StatusCreated, status)
 	suite.Equal("{\"message\":\"Successfully registered\"}", rspBody)
@@ -234,7 +224,6 @@ func (suite *RegistrationTestSuite) TestSuccessfulRegistrationDelete() {
 
 	RegistrationDeleteHandler(suite.rec, req)
 
-	//nolint:bodyclose
 	status, rspBody := statusAndBodyFromReq(suite)
 	suite.Equal(http.StatusNoContent, status)
 	suite.Equal("", rspBody)
@@ -257,7 +246,6 @@ func (suite *RegistrationTestSuite) TestNotOrgAdminDelete() {
 
 	RegistrationDeleteHandler(suite.rec, req)
 
-	//nolint:bodyclose
 	status, rspBody := statusAndBodyFromReq(suite)
 	suite.Equal(http.StatusForbidden, status)
 	suite.Equal("{\"message\":\"user must be org admin to register satellite\"}", rspBody)
@@ -277,13 +265,13 @@ func (suite *RegistrationTestSuite) TestRegistrationNotFoundDelete() {
 
 	RegistrationDeleteHandler(suite.rec, req)
 
-	//nolint:bodyclose
 	status, rspBody := statusAndBodyFromReq(suite)
 	suite.Equal(http.StatusNotFound, status)
 	suite.Equal("{\"message\":\"registration not found\"}", rspBody)
 }
 
 func statusAndBodyFromReq(suite *RegistrationTestSuite) (int, string) {
+	//nolint:bodyclose
 	rsp := suite.rec.Result()
 	body, _ := io.ReadAll(rsp.Body)
 	return rsp.StatusCode, string(body)

--- a/internal/handlers/registration_handler_test.go
+++ b/internal/handlers/registration_handler_test.go
@@ -53,7 +53,9 @@ func (suite *RegistrationTestSuite) TestEmptyBodyCreate() {
 	RegistrationCreateHandler(suite.rec, req)
 
 	//nolint:bodyclose
-	suite.Equal(http.StatusBadRequest, suite.rec.Result().StatusCode)
+	status, rspBody := statusAndBodyFromReq(suite)
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("{\"message\":\"required parameter [uid] not found in body\"}", rspBody)
 }
 
 func (suite *RegistrationTestSuite) TestNoBodyCreate() {
@@ -63,7 +65,9 @@ func (suite *RegistrationTestSuite) TestNoBodyCreate() {
 	RegistrationCreateHandler(suite.rec, req)
 
 	//nolint:bodyclose
-	suite.Equal(http.StatusBadRequest, suite.rec.Result().StatusCode)
+	status, rspBody := statusAndBodyFromReq(suite)
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("{\"message\":\"failed to unmarshal body: unexpected end of JSON input\"}", rspBody)
 }
 
 func (suite *RegistrationTestSuite) TestBadBodyCreate() {
@@ -73,7 +77,9 @@ func (suite *RegistrationTestSuite) TestBadBodyCreate() {
 	RegistrationCreateHandler(suite.rec, req)
 
 	//nolint:bodyclose
-	suite.Equal(http.StatusBadRequest, suite.rec.Result().StatusCode)
+	status, rspBody := statusAndBodyFromReq(suite)
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("{\"message\":\"failed to unmarshal body: unexpected end of JSON input\"}", rspBody)
 }
 
 func (suite *RegistrationTestSuite) TestNotOrgAdminCreate() {
@@ -90,7 +96,9 @@ func (suite *RegistrationTestSuite) TestNotOrgAdminCreate() {
 	RegistrationCreateHandler(suite.rec, req)
 
 	//nolint:bodyclose
-	suite.Equal(http.StatusForbidden, suite.rec.Result().StatusCode)
+	status, rspBody := statusAndBodyFromReq(suite)
+	suite.Equal(http.StatusForbidden, status)
+	suite.Equal("{\"message\":\"user must be org admin to register satellite\"}", rspBody)
 }
 
 func (suite *RegistrationTestSuite) TestNoGatewayCNCreate() {
@@ -107,7 +115,9 @@ func (suite *RegistrationTestSuite) TestNoGatewayCNCreate() {
 	RegistrationCreateHandler(suite.rec, req)
 
 	//nolint:bodyclose
-	suite.Equal(http.StatusBadRequest, suite.rec.Result().StatusCode)
+	status, rspBody := statusAndBodyFromReq(suite)
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("{\"message\":\"[x-rh-certauth-cn] header not present\"}", rspBody)
 }
 
 func (suite *RegistrationTestSuite) TestNotMatchingCNCreate() {
@@ -125,7 +135,9 @@ func (suite *RegistrationTestSuite) TestNotMatchingCNCreate() {
 	RegistrationCreateHandler(suite.rec, req)
 
 	//nolint:bodyclose
-	suite.Equal(http.StatusForbidden, suite.rec.Result().StatusCode)
+	status, rspBody := statusAndBodyFromReq(suite)
+	suite.Equal(http.StatusForbidden, status)
+	suite.Equal("{\"message\":\"user must be org admin to register satellite\"}", rspBody)
 }
 
 func (suite *RegistrationTestSuite) TestExistingRegistrationCreate() {
@@ -143,7 +155,9 @@ func (suite *RegistrationTestSuite) TestExistingRegistrationCreate() {
 	RegistrationCreateHandler(suite.rec, req)
 
 	//nolint:bodyclose
-	suite.Equal(http.StatusConflict, suite.rec.Result().StatusCode)
+	status, rspBody := statusAndBodyFromReq(suite)
+	suite.Equal(http.StatusConflict, status)
+	suite.Equal("{\"message\":\"existing registration found\"}", rspBody)
 }
 
 func (suite *RegistrationTestSuite) TestExistingUidCreate() {
@@ -161,7 +175,9 @@ func (suite *RegistrationTestSuite) TestExistingUidCreate() {
 	RegistrationCreateHandler(suite.rec, req)
 
 	//nolint:bodyclose
-	suite.Equal(http.StatusConflict, suite.rec.Result().StatusCode)
+	status, rspBody := statusAndBodyFromReq(suite)
+	suite.Equal(http.StatusConflict, status)
+	suite.Equal("{\"message\":\"existing registration found\"}", rspBody)
 }
 
 func (suite *RegistrationTestSuite) TestSuccessfulRegistrationCreate() {
@@ -176,7 +192,9 @@ func (suite *RegistrationTestSuite) TestSuccessfulRegistrationCreate() {
 	RegistrationCreateHandler(suite.rec, req)
 
 	//nolint:bodyclose
-	suite.Equal(http.StatusCreated, suite.rec.Result().StatusCode)
+	status, rspBody := statusAndBodyFromReq(suite)
+	suite.Equal(http.StatusCreated, status)
+	suite.Equal("{\"message\":\"Successfully registered\"}", rspBody)
 }
 
 // This is mostly just to test the "other" format of CN headers that the gateway
@@ -194,7 +212,9 @@ func (suite *RegistrationTestSuite) TestSuccessfulRegistrationCreateOtherUIDForm
 	RegistrationCreateHandler(suite.rec, req)
 
 	//nolint:bodyclose
-	suite.Equal(http.StatusCreated, suite.rec.Result().StatusCode)
+	status, rspBody := statusAndBodyFromReq(suite)
+	suite.Equal(http.StatusCreated, status)
+	suite.Equal("{\"message\":\"Successfully registered\"}", rspBody)
 }
 
 func (suite *RegistrationTestSuite) TestSuccessfulRegistrationDelete() {
@@ -215,9 +235,9 @@ func (suite *RegistrationTestSuite) TestSuccessfulRegistrationDelete() {
 	RegistrationDeleteHandler(suite.rec, req)
 
 	//nolint:bodyclose
-	status, body := statusAndBodyFromReq(suite)
+	status, rspBody := statusAndBodyFromReq(suite)
 	suite.Equal(http.StatusNoContent, status)
-	suite.Equal("", body)
+	suite.Equal("", rspBody)
 }
 
 func (suite *RegistrationTestSuite) TestNotOrgAdminDelete() {
@@ -238,9 +258,9 @@ func (suite *RegistrationTestSuite) TestNotOrgAdminDelete() {
 	RegistrationDeleteHandler(suite.rec, req)
 
 	//nolint:bodyclose
-	status, body := statusAndBodyFromReq(suite)
+	status, rspBody := statusAndBodyFromReq(suite)
 	suite.Equal(http.StatusForbidden, status)
-	suite.Equal("{\"message\":\"user must be org admin to register satellite\"}", body)
+	suite.Equal("{\"message\":\"user must be org admin to register satellite\"}", rspBody)
 }
 
 func (suite *RegistrationTestSuite) TestRegistrationNotFoundDelete() {
@@ -258,9 +278,9 @@ func (suite *RegistrationTestSuite) TestRegistrationNotFoundDelete() {
 	RegistrationDeleteHandler(suite.rec, req)
 
 	//nolint:bodyclose
-	status, body := statusAndBodyFromReq(suite)
+	status, rspBody := statusAndBodyFromReq(suite)
 	suite.Equal(http.StatusNotFound, status)
-	suite.Equal("{\"message\":\"registration not found\"}", body)
+	suite.Equal("{\"message\":\"registration not found\"}", rspBody)
 }
 
 func statusAndBodyFromReq(suite *RegistrationTestSuite) (int, string) {


### PR DESCRIPTION
[Fix 204 No Content response on registration DELETE](https://github.com/RedHatInsights/mbop/commit/393958e14ba1a8bcca78a9c94c0b6991f0a57d67) 

Since a 204 cannot have a message body [1] this sets the DELETE on registrations
to use `w.WriteHeader(204)` directly, vs the JSON helper.

Requests do work and successfully return a 204 on this currently, however an
error is logged while writing the response in the application:

```
ERROR handlers/helpers.go:30 error writing response {"error": "http: request method or response status code does not allow body"}
```

This also adds some explicit expectations to the response body in the tests.

[1] https://www.rfc-editor.org/rfc/rfc7231#section-6.3.5