### PR TITLE
Add DisplayName support to /v1/registrations

### DIFF
--- a/internal/handlers/registration_handler.go
+++ b/internal/handlers/registration_handler.go
@@ -12,7 +12,8 @@ import (
 )
 
 type registationCreateRequest struct {
-	UID *string `json:"uid,omitempty"`
+	UID         *string `json:"uid,omitempty"`
+	DisplayName *string `json:"display_name,omitempty"`
 }
 
 func RegistrationCreateHandler(w http.ResponseWriter, r *http.Request) {
@@ -31,6 +32,11 @@ func RegistrationCreateHandler(w http.ResponseWriter, r *http.Request) {
 
 	if body.UID == nil || *body.UID == "" {
 		do400(w, "required parameter [uid] not found in body")
+		return
+	}
+
+	if body.DisplayName == nil || *body.DisplayName == "" {
+		do400(w, "required parameter [display_name] not found in body")
 		return
 	}
 
@@ -59,8 +65,9 @@ func RegistrationCreateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_, err = db.Create(&store.Registration{
-		OrgID: id.Identity.OrgID,
-		UID:   *body.UID,
+		OrgID:       id.Identity.OrgID,
+		UID:         *body.UID,
+		DisplayName: *body.DisplayName,
 	})
 	if err != nil {
 		if errors.Is(err, store.ErrRegistrationAlreadyExists) {

--- a/internal/handlers/registration_handler.go
+++ b/internal/handlers/registration_handler.go
@@ -63,7 +63,7 @@ func RegistrationCreateHandler(w http.ResponseWriter, r *http.Request) {
 		UID:   *body.UID,
 	})
 	if err != nil {
-		if errors.Is(err, store.ErrUIDAlreadyExists) {
+		if errors.Is(err, store.ErrRegistrationAlreadyExists) {
 			doError(w, "existing registration found", 409)
 		} else {
 			do500(w, "failed to create registration: "+err.Error())

--- a/internal/handlers/registration_handler_test.go
+++ b/internal/handlers/registration_handler_test.go
@@ -68,6 +68,17 @@ func (suite *RegistrationTestSuite) TestNoBodyCreate() {
 	suite.Equal("{\"message\":\"failed to unmarshal body: unexpected end of JSON input\"}", rspBody)
 }
 
+func (suite *RegistrationTestSuite) TestNoDisplayNameCreate() {
+	body := []byte(`{"uid": "1234"}`)
+	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body)).
+		WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{}))
+	RegistrationCreateHandler(suite.rec, req)
+
+	status, rspBody := statusAndBodyFromReq(suite)
+	suite.Equal(http.StatusBadRequest, status)
+	suite.Equal("{\"message\":\"required parameter [display_name] not found in body\"}", rspBody)
+}
+
 func (suite *RegistrationTestSuite) TestBadBodyCreate() {
 	body := []byte(`{`)
 	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body)).
@@ -83,7 +94,7 @@ func (suite *RegistrationTestSuite) TestNotOrgAdminCreate() {
 	_, err := suite.store.Create(&store.Registration{UID: "abc1234"})
 	suite.Nil(err)
 
-	body := []byte(`{"uid": "abc1234"}`)
+	body := []byte(`{"uid": "abc1234", "display_name": "foobar"}`)
 	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body)).
 		WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{Identity: identity.Identity{
 			User:  identity.User{OrgAdmin: false},
@@ -101,7 +112,7 @@ func (suite *RegistrationTestSuite) TestNoGatewayCNCreate() {
 	_, err := suite.store.Create(&store.Registration{UID: "abc1234"})
 	suite.Nil(err)
 
-	body := []byte(`{"uid": "abc1234"}`)
+	body := []byte(`{"uid": "abc1234", "display_name": "foobar"}`)
 	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body)).
 		WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{Identity: identity.Identity{
 			User:  identity.User{OrgAdmin: true},
@@ -119,7 +130,7 @@ func (suite *RegistrationTestSuite) TestNotMatchingCNCreate() {
 	_, err := suite.store.Create(&store.Registration{UID: "abc1234"})
 	suite.Nil(err)
 
-	body := []byte(`{"uid": "abc1234"}`)
+	body := []byte(`{"uid": "abc1234", "display_name": "foobar"}`)
 	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body)).
 		WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{Identity: identity.Identity{
 			User:  identity.User{OrgAdmin: false},
@@ -138,7 +149,7 @@ func (suite *RegistrationTestSuite) TestExistingRegistrationCreate() {
 	_, err := suite.store.Create(&store.Registration{UID: "abc1234", OrgID: "1234"})
 	suite.Nil(err)
 
-	body := []byte(`{"uid": "abc1234"}`)
+	body := []byte(`{"uid": "abc1234", "display_name": "foobar"}`)
 	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body)).
 		WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{Identity: identity.Identity{
 			User:  identity.User{OrgAdmin: true},
@@ -157,7 +168,7 @@ func (suite *RegistrationTestSuite) TestExistingUidCreate() {
 	_, err := suite.store.Create(&store.Registration{UID: "abc1234", OrgID: "2345"})
 	suite.Nil(err)
 
-	body := []byte(`{"uid": "abc1234"}`)
+	body := []byte(`{"uid": "abc1234", "display_name": "foobar"}`)
 	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body)).
 		WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{Identity: identity.Identity{
 			User:  identity.User{OrgAdmin: true},
@@ -173,7 +184,7 @@ func (suite *RegistrationTestSuite) TestExistingUidCreate() {
 }
 
 func (suite *RegistrationTestSuite) TestSuccessfulRegistrationCreate() {
-	body := []byte(`{"uid": "abc1234"}`)
+	body := []byte(`{"uid": "abc1234", "display_name": "foobar"}`)
 	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body)).
 		WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{Identity: identity.Identity{
 			User:  identity.User{OrgAdmin: true},
@@ -192,7 +203,7 @@ func (suite *RegistrationTestSuite) TestSuccessfulRegistrationCreate() {
 // passes through. Currently it's the case that the CN is the last field in the
 // header, but that may not always be the case.
 func (suite *RegistrationTestSuite) TestSuccessfulRegistrationCreateOtherUIDFormat() {
-	body := []byte(`{"uid": "bar"}`)
+	body := []byte(`{"uid": "bar", "display_name": "foobar"}`)
 	req := httptest.NewRequest("POST", "http://foobar/registrations", bytes.NewReader(body)).
 		WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{Identity: identity.Identity{
 			User:  identity.User{OrgAdmin: true},

--- a/internal/store/in_memory_store_impl.go
+++ b/internal/store/in_memory_store_impl.go
@@ -36,7 +36,7 @@ func (m *inMemoryStore) Create(r *Registration) (string, error) {
 
 	for i := range m.db {
 		if m.db[i].UID == r.UID {
-			return "", ErrUIDAlreadyExists
+			return "", ErrRegistrationAlreadyExists
 		}
 	}
 

--- a/internal/store/in_memory_store_impl.go
+++ b/internal/store/in_memory_store_impl.go
@@ -38,6 +38,9 @@ func (m *inMemoryStore) Create(r *Registration) (string, error) {
 		if m.db[i].UID == r.UID {
 			return "", ErrRegistrationAlreadyExists
 		}
+		if m.db[i].DisplayName == r.DisplayName {
+			return "", ErrRegistrationAlreadyExists
+		}
 	}
 
 	m.db = append(m.db, *r)

--- a/internal/store/in_memory_store_impl_test.go
+++ b/internal/store/in_memory_store_impl_test.go
@@ -53,9 +53,9 @@ func (suite *InMemoryStoreTestSuite) TestFindByUIDNotThere() {
 }
 
 func (suite *InMemoryStoreTestSuite) TestAll() {
-	_, err := suite.store.Create(&Registration{OrgID: "1234", UID: "1234"})
+	_, err := suite.store.Create(&Registration{OrgID: "1234", UID: "1234", DisplayName: "one"})
 	suite.Nil(err)
-	_, err = suite.store.Create(&Registration{OrgID: "2345", UID: "2345"})
+	_, err = suite.store.Create(&Registration{OrgID: "2345", UID: "2345", DisplayName: "two"})
 	suite.Nil(err)
 
 	r, err := suite.store.All()

--- a/internal/store/migrations/2_add_display_name.down.sql
+++ b/internal/store/migrations/2_add_display_name.down.sql
@@ -1,2 +1,5 @@
 alter table public.registrations
     drop column if exists display_name;
+
+alter table public.registrations
+    drop constraint if exists display_name_unique;

--- a/internal/store/migrations/2_add_display_name.down.sql
+++ b/internal/store/migrations/2_add_display_name.down.sql
@@ -1,0 +1,2 @@
+alter table public.registrations
+    drop column if exists display_name;

--- a/internal/store/migrations/2_add_display_name.up.sql
+++ b/internal/store/migrations/2_add_display_name.up.sql
@@ -1,0 +1,19 @@
+alter table registrations
+    add display_name varchar default NULL;
+
+-- backfill all null display names
+do
+$$
+    declare
+        row RECORD;
+    begin
+        for row in
+            select * from registrations where display_name is null
+            loop
+                update registrations set display_name = uid where id = row.id;
+            end loop;
+    end
+$$;
+
+create unique index display_name_unique
+    on registrations (display_name);

--- a/internal/store/migrations/2_add_display_name.up.sql
+++ b/internal/store/migrations/2_add_display_name.up.sql
@@ -15,5 +15,7 @@ $$
     end
 $$;
 
-create unique index display_name_unique
-    on registrations (display_name);
+-- unique across multiple tenants per display name
+alter table registrations
+    add constraint display_name_unique
+        unique (display_name);

--- a/internal/store/postgres_store_impl_test.go
+++ b/internal/store/postgres_store_impl_test.go
@@ -58,6 +58,16 @@ func (suite *TestSuite) TestCreateWithExtra() {
 	suite.NotEqual("", id, "something funky with returning the id")
 }
 
+func (suite *TestSuite) TestCreateDuplicateDisplayName() {
+	r := Registration{OrgID: "1234", UID: "1234", DisplayName: "dupe"}
+	_, err := suite.store.Create(&r)
+	suite.Nil(err, "failed to insert")
+
+	r2 := Registration{OrgID: "2345", UID: "2345", DisplayName: "dupe"}
+	_, err = suite.store.Create(&r2)
+	suite.Error(err, "inserted successfully even when it shouldn't have")
+}
+
 func (suite *TestSuite) TestDelete() {
 	r := Registration{OrgID: "1234", UID: "1234", Extra: map[string]interface{}{"thing": true}}
 	_, err := suite.store.Create(&r)
@@ -105,12 +115,13 @@ func (suite *TestSuite) TestFindOneNotThere() {
 }
 
 func (suite *TestSuite) TestFindAll() {
-	r := Registration{OrgID: "1234", UID: "1234"}
+	r := Registration{OrgID: "1234", UID: "1234", DisplayName: "one"}
 	_, err := suite.store.Create(&r)
 	suite.Nil(err, "failed to insert")
 
 	r.OrgID = "2345"
 	r.UID = "2345"
+	r.DisplayName = "two"
 	_, err = suite.store.Create(&r)
 	suite.Nil(err, "failed to insert")
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -17,7 +17,6 @@ var mem Store
 
 var (
 	ErrRegistrationAlreadyExists = errors.New("registration already exists")
-	ErrUIDAlreadyExists          = errors.New("uid already exists")
 	ErrRegistrationNotFound      = errors.New("registration not found")
 )
 

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -4,15 +4,17 @@ package store
 Registration represents an instance of a satellite that is registered via:
 - OrgID; comes from keycloak
 - Uid; the CN from the satellite certificate
+- DisplayName; the name to display in the UI for the satellite
 
 ID is a generated UUID
 Extra is just a jsonb column if we want to store some extra metadata someday
 */
 type Registration struct {
-	ID    string
-	OrgID string
-	UID   string
-	Extra map[string]interface{}
+	ID          string
+	OrgID       string
+	UID         string
+	DisplayName string
+	Extra       map[string]interface{}
 }
 
 type RegistrationUpdate struct {


### PR DESCRIPTION
Title says it all. This PR adds `display_name` to the db schema and support for passing it in through the handler. 

Notable stuff:
- required in the handler, so both `uid` and `display_name` need to be passed through 
- unique globally (just like UID)