### PR TITLE
Add GET /v1/registrations

### DIFF
--- a/cmd/mbop/mbop.go
+++ b/cmd/mbop/mbop.go
@@ -43,6 +43,7 @@ func main() {
 
 	// all the handlers that need xrhid
 	r.With(identity.EnforceIdentity).Group(func(r chi.Router) {
+		r.Get("/v1/registrations", handlers.RegistrationListHandler)
 		r.Post("/v1/registrations", handlers.RegistrationCreateHandler)
 		r.Delete("/v1/registrations/{uid}", handlers.RegistrationDeleteHandler)
 		r.Get("/v1/registrations/token", handlers.TokenHandler)

--- a/internal/handlers/registration_handler.go
+++ b/internal/handlers/registration_handler.go
@@ -16,6 +16,24 @@ type registationCreateRequest struct {
 	DisplayName *string `json:"display_name,omitempty"`
 }
 
+func RegistrationListHandler(w http.ResponseWriter, r *http.Request) {
+	id := identity.Get(r.Context())
+	if !id.Identity.User.OrgAdmin {
+		doError(w, "user must be org admin to list registrations", 403)
+		return
+	}
+
+	db := store.GetStore()
+
+	regs, err := db.All(id.Identity.OrgID)
+	if err != nil {
+		do500(w, err.Error())
+		return
+	}
+
+	sendJSON(w, regs)
+}
+
 func RegistrationCreateHandler(w http.ResponseWriter, r *http.Request) {
 	b, err := io.ReadAll(r.Body)
 	if err != nil {

--- a/internal/handlers/registration_handler_test.go
+++ b/internal/handlers/registration_handler_test.go
@@ -287,3 +287,17 @@ func statusAndBodyFromReq(suite *RegistrationTestSuite) (int, string) {
 	body, _ := io.ReadAll(rsp.Body)
 	return rsp.StatusCode, string(body)
 }
+
+func (suite *RegistrationTestSuite) TestRegistrationList() {
+	req := httptest.NewRequest(http.MethodGet, "http://foobar/registrations", nil)
+	req = req.WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{Identity: identity.Identity{
+		User:  identity.User{OrgAdmin: true},
+		OrgID: "1234",
+	}}))
+
+	RegistrationListHandler(suite.rec, req)
+
+	status, rspBody := statusAndBodyFromReq(suite)
+	suite.Equal(http.StatusNotFound, status)
+	suite.Equal("{\"message\":\"registration not found\"}", rspBody)
+}

--- a/internal/handlers/registration_handler_test.go
+++ b/internal/handlers/registration_handler_test.go
@@ -3,11 +3,13 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/redhatinsights/mbop/internal/config"
@@ -281,14 +283,10 @@ func (suite *RegistrationTestSuite) TestRegistrationNotFoundDelete() {
 	suite.Equal("{\"message\":\"registration not found\"}", rspBody)
 }
 
-func statusAndBodyFromReq(suite *RegistrationTestSuite) (int, string) {
-	//nolint:bodyclose
-	rsp := suite.rec.Result()
-	body, _ := io.ReadAll(rsp.Body)
-	return rsp.StatusCode, string(body)
-}
-
 func (suite *RegistrationTestSuite) TestRegistrationList() {
+	_, err := suite.store.Create(&store.Registration{UID: "abc1234", OrgID: "1234", DisplayName: "a test"})
+	suite.Nil(err)
+
 	req := httptest.NewRequest(http.MethodGet, "http://foobar/registrations", nil)
 	req = req.WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{Identity: identity.Identity{
 		User:  identity.User{OrgAdmin: true},
@@ -298,6 +296,28 @@ func (suite *RegistrationTestSuite) TestRegistrationList() {
 	RegistrationListHandler(suite.rec, req)
 
 	status, rspBody := statusAndBodyFromReq(suite)
-	suite.Equal(http.StatusNotFound, status)
-	suite.Equal("{\"message\":\"registration not found\"}", rspBody)
+	suite.Equal(http.StatusOK, status)
+
+	var body registrationCollection
+	var raw map[string]any
+	suite.Nil(json.Unmarshal([]byte(rspBody), &body))
+	suite.Nil(json.Unmarshal([]byte(rspBody), &raw))
+
+	suite.Equal("a test", body.Registrations[0].DisplayName)
+	suite.Equal("abc1234", body.Registrations[0].UID)
+	suite.Equal(1, body.Meta.Count)
+
+	regs := raw["registrations"].([]any)
+	r := regs[0].(map[string]any)
+	t, err := time.Parse(time.RFC3339, r["created_at"].(string))
+
+	suite.Nil(err)
+	suite.WithinDuration(time.Now(), t, 5*time.Second)
+}
+
+func statusAndBodyFromReq(suite *RegistrationTestSuite) (int, string) {
+	//nolint:bodyclose
+	rsp := suite.rec.Result()
+	body, _ := io.ReadAll(rsp.Body)
+	return rsp.StatusCode, string(body)
 }

--- a/internal/store/in_memory_store_impl.go
+++ b/internal/store/in_memory_store_impl.go
@@ -1,17 +1,19 @@
 package store
 
+import "time"
+
 type inMemoryStore struct {
 	db []Registration
 }
 
-func (m *inMemoryStore) All(orgID string) ([]Registration, error) {
+func (m *inMemoryStore) All(orgID string, page, pageSize int) ([]Registration, int, error) {
 	out := make([]Registration, 0)
 	for i := range m.db {
 		if m.db[i].OrgID == orgID {
 			out = append(out, m.db[i])
 		}
 	}
-	return out, nil
+	return out, len(out), nil
 }
 
 func (m *inMemoryStore) Find(orgID string, uid string) (*Registration, error) {
@@ -49,6 +51,7 @@ func (m *inMemoryStore) Create(r *Registration) (string, error) {
 		}
 	}
 
+	r.CreatedAt = time.Now()
 	m.db = append(m.db, *r)
 	return "", nil
 }

--- a/internal/store/in_memory_store_impl.go
+++ b/internal/store/in_memory_store_impl.go
@@ -4,8 +4,14 @@ type inMemoryStore struct {
 	db []Registration
 }
 
-func (m *inMemoryStore) All() ([]Registration, error) {
-	return m.db, nil
+func (m *inMemoryStore) All(orgID string) ([]Registration, error) {
+	out := make([]Registration, 0)
+	for i := range m.db {
+		if m.db[i].OrgID == orgID {
+			out = append(out, m.db[i])
+		}
+	}
+	return out, nil
 }
 
 func (m *inMemoryStore) Find(orgID string, uid string) (*Registration, error) {

--- a/internal/store/in_memory_store_impl_test.go
+++ b/internal/store/in_memory_store_impl_test.go
@@ -58,10 +58,10 @@ func (suite *InMemoryStoreTestSuite) TestAll() {
 	_, err = suite.store.Create(&Registration{OrgID: "2345", UID: "2345", DisplayName: "two"})
 	suite.Nil(err)
 
-	r, err := suite.store.All()
+	r, err := suite.store.All("1234")
 	suite.Nil(err)
 
-	suite.Equal(len(r), 2)
+	suite.Equal(len(r), 1)
 }
 
 func (suite *InMemoryStoreTestSuite) TestDelete() {

--- a/internal/store/in_memory_store_impl_test.go
+++ b/internal/store/in_memory_store_impl_test.go
@@ -58,10 +58,10 @@ func (suite *InMemoryStoreTestSuite) TestAll() {
 	_, err = suite.store.Create(&Registration{OrgID: "2345", UID: "2345", DisplayName: "two"})
 	suite.Nil(err)
 
-	r, err := suite.store.All("1234")
+	_, count, err := suite.store.All("1234", 0, 0)
 	suite.Nil(err)
 
-	suite.Equal(len(r), 1)
+	suite.Equal(count, 1)
 }
 
 func (suite *InMemoryStoreTestSuite) TestDelete() {

--- a/internal/store/interface.go
+++ b/internal/store/interface.go
@@ -1,7 +1,7 @@
 package store
 
 type Store interface {
-	All(orgID string) ([]Registration, error)
+	All(orgID string, limit, offset int) ([]Registration, int, error)
 	// Find a registration that both the org ID + UID match
 	Find(orgID, uid string) (*Registration, error)
 	// lookup a registration by uid only

--- a/internal/store/interface.go
+++ b/internal/store/interface.go
@@ -1,7 +1,7 @@
 package store
 
 type Store interface {
-	All() ([]Registration, error)
+	All(orgID string) ([]Registration, error)
 	// Find a registration that both the org ID + UID match
 	Find(orgID, uid string) (*Registration, error)
 	// lookup a registration by uid only

--- a/internal/store/postgres_store_impl.go
+++ b/internal/store/postgres_store_impl.go
@@ -15,8 +15,8 @@ type postgresStore struct {
 	db *sql.DB
 }
 
-func (p *postgresStore) All() ([]Registration, error) {
-	rows, err := p.db.Query(`select id, org_id, uid, display_name, extra from registrations`)
+func (p *postgresStore) All(orgID string) ([]Registration, error) {
+	rows, err := p.db.Query(`select id, org_id, uid, display_name, extra from registrations where org_id = $1`, orgID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/postgres_store_impl.go
+++ b/internal/store/postgres_store_impl.go
@@ -3,6 +3,7 @@ package store
 import (
 	"database/sql"
 	"encoding/json"
+	"time"
 
 	// the pgx driver for the database
 	_ "github.com/golang-migrate/migrate/v4/database/pgx"
@@ -15,10 +16,19 @@ type postgresStore struct {
 	db *sql.DB
 }
 
-func (p *postgresStore) All(orgID string) ([]Registration, error) {
-	rows, err := p.db.Query(`select id, org_id, uid, display_name, extra from registrations where org_id = $1`, orgID)
+func (p *postgresStore) All(orgID string, limit, offset int) ([]Registration, int, error) {
+	rows, err := p.db.Query(`select
+	id, org_id, uid, display_name, extra, created_at
+	from registrations
+	where org_id = $1
+	order by created_at desc
+	limit $2
+	offset $3`,
+		orgID,
+		limit,
+		offset)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer rows.Close()
 
@@ -26,17 +36,23 @@ func (p *postgresStore) All(orgID string) ([]Registration, error) {
 	for rows.Next() {
 		r, err := scanRegistration(rows)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		out = append(out, *r)
 	}
 
-	return out, nil
+	var count int
+	row := p.db.QueryRow(`select count(id) from registrations where org_id = $1`, orgID)
+	if err := row.Scan(&count); err != nil {
+		return nil, 0, err
+	}
+
+	return out, count, nil
 }
 
 func (p *postgresStore) Find(orgID, uid string) (*Registration, error) {
 	rows := p.db.QueryRow(
-		`select id, org_id, uid, display_name, extra from registrations where org_id = $1 and uid = $2 limit 1`,
+		`select id, org_id, uid, display_name, extra, created_at from registrations where org_id = $1 and uid = $2 limit 1`,
 		orgID,
 		uid,
 	)
@@ -44,7 +60,7 @@ func (p *postgresStore) Find(orgID, uid string) (*Registration, error) {
 }
 
 func (p *postgresStore) FindByUID(uid string) (*Registration, error) {
-	rows := p.db.QueryRow(`select id, org_id, uid, display_name, extra from registrations where uid = $1 limit 1`, uid)
+	rows := p.db.QueryRow(`select id, org_id, uid, display_name, extra, created_at from registrations where uid = $1 limit 1`, uid)
 	return scanRegistration(rows)
 }
 
@@ -122,8 +138,9 @@ func scanRegistration(row scanner) (*Registration, error) {
 		uid         string
 		displayName string
 		extra       []byte
+		createdAt   time.Time
 	)
-	err := row.Scan(&id, &orgID, &uid, &displayName, &extra)
+	err := row.Scan(&id, &orgID, &uid, &displayName, &extra, &createdAt)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrRegistrationNotFound
@@ -145,5 +162,6 @@ func scanRegistration(row scanner) (*Registration, error) {
 		UID:         uid,
 		DisplayName: displayName,
 		Extra:       e,
+		CreatedAt:   createdAt,
 	}, nil
 }

--- a/internal/store/postgres_store_impl_test.go
+++ b/internal/store/postgres_store_impl_test.go
@@ -119,13 +119,13 @@ func (suite *TestSuite) TestFindAll() {
 	_, err := suite.store.Create(&r)
 	suite.Nil(err, "failed to insert")
 
-	r.OrgID = "2345"
+	r.OrgID = "1234"
 	r.UID = "2345"
 	r.DisplayName = "two"
 	_, err = suite.store.Create(&r)
 	suite.Nil(err, "failed to insert")
 
-	out, err := suite.store.All()
+	out, err := suite.store.All("1234")
 	suite.Nil(err, "failed to list all registrations")
 	suite.Equal(len(out), 2)
 }

--- a/internal/store/postgres_store_impl_test.go
+++ b/internal/store/postgres_store_impl_test.go
@@ -2,7 +2,9 @@ package store
 
 import (
 	"database/sql"
+	"strconv"
 	"testing"
+	"time"
 
 	l "github.com/redhatinsights/mbop/internal/logger"
 	"github.com/stretchr/testify/suite"
@@ -91,6 +93,7 @@ func (suite *TestSuite) TestFindOne() {
 	suite.Nil(err, "failed to find one registration")
 	suite.Equal(found.UID, "1234")
 	suite.Equal(found.OrgID, "1234")
+	suite.WithinDuration(found.CreatedAt, time.Now(), 5*time.Second)
 }
 
 func (suite *TestSuite) TestFindByUID() {
@@ -102,6 +105,7 @@ func (suite *TestSuite) TestFindByUID() {
 	suite.Nil(err, "failed to find one registration")
 	suite.Equal(found.UID, "1234")
 	suite.Equal(found.OrgID, "1234")
+	suite.WithinDuration(found.CreatedAt, time.Now(), 5*time.Second)
 }
 
 func (suite *TestSuite) TestFindByUIDNotThere() {
@@ -125,9 +129,9 @@ func (suite *TestSuite) TestFindAll() {
 	_, err = suite.store.Create(&r)
 	suite.Nil(err, "failed to insert")
 
-	out, err := suite.store.All("1234")
+	_, count, err := suite.store.All("1234", 0, 0)
 	suite.Nil(err, "failed to list all registrations")
-	suite.Equal(len(out), 2)
+	suite.Equal(count, 2)
 }
 
 func (suite *TestSuite) TestUpdate() {
@@ -140,4 +144,36 @@ func (suite *TestSuite) TestUpdate() {
 		&RegistrationUpdate{Extra: &map[string]interface{}{"thing": true}},
 	)
 	suite.Nil(err, "failed to update registration")
+}
+
+func (suite *TestSuite) TestFindAllWithPagination() {
+	for i := 0; i < 10; i++ {
+		s := strconv.Itoa(i)
+		_, err := suite.store.Create(&Registration{
+			OrgID:       "a",
+			UID:         s,
+			DisplayName: s,
+		})
+		suite.Nil(err)
+	}
+
+	// stepping through the pages ensuring they start/end with where it's expected
+	regs, count, err := suite.store.All("a", 5, 0)
+	suite.Nil(err)
+	suite.Equal(10, count)
+	suite.Equal(5, len(regs))
+	suite.Equal("9", regs[0].UID)
+	suite.Equal("5", regs[len(regs)-1].UID)
+
+	regs, count, err = suite.store.All("a", 5, 5)
+	suite.Nil(err)
+	suite.Equal(10, count)
+	suite.Equal(5, len(regs))
+	suite.Equal("4", regs[0].UID)
+	suite.Equal("0", regs[len(regs)-1].UID)
+
+	regs, count, err = suite.store.All("a", 5, 10)
+	suite.Nil(err)
+	suite.Equal(10, count)
+	suite.Equal(0, len(regs))
 }

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -1,5 +1,7 @@
 package store
 
+import "time"
+
 /*
 Registration represents an instance of a satellite that is registered via:
 - OrgID; comes from keycloak
@@ -15,6 +17,7 @@ type Registration struct {
 	UID         string
 	DisplayName string
 	Extra       map[string]interface{}
+	CreatedAt   time.Time
 }
 
 type RegistrationUpdate struct {


### PR DESCRIPTION
This PR adds a new endpoint: `GET /v1/registrations` that returns registrations for the current user's org (pulled from the xrhid header).

Notable things:
- pagination handled by limit/offset since there are helpers to pull them (thanks alec), default limit is 100
- ordered by `created_at desc` so the newest are first, can maybe add a sort query param later
- endpoint limited to org_admins

output format:
```json
{
	"registrations": [
		{
			"uid": "1234",
			"display_name": "my custom satellite yo",
			"created_at": "2023-03-13T17:03:25.863491Z"
		}
	],
	"meta": {
		"count": 1
	}
}
```