### PR TITLE
Add the `fetchLabels=true` query param to `/api/accounts_mgmt/v1/accounts` calls

### DIFF
--- a/internal/service/ocm/ocm_impl.go
+++ b/internal/service/ocm/ocm_impl.go
@@ -55,7 +55,7 @@ func (ocm *SDK) InitSdkConnection(ctx context.Context) error {
 
 func (ocm *SDK) GetUsers(usernames models.UserBody, q models.UserV1Query) (models.Users, error) {
 	search := createSearchString(usernames)
-	collection := ocm.client.AccountsMgmt().V1().Accounts().List().Search(search)
+	collection := ocm.client.AccountsMgmt().V1().Accounts().List().Parameter("fetchLabels", true).Search(search)
 
 	collection = collection.Order(createQueryOrder(q))
 

--- a/internal/service/ocm/ocm_impl.go
+++ b/internal/service/ocm/ocm_impl.go
@@ -55,7 +55,12 @@ func (ocm *SDK) InitSdkConnection(ctx context.Context) error {
 
 func (ocm *SDK) GetUsers(usernames models.UserBody, q models.UserV1Query) (models.Users, error) {
 	search := createSearchString(usernames)
-	collection := ocm.client.AccountsMgmt().V1().Accounts().List().Parameter("fetchLabels", true).Search(search)
+	collection := ocm.client.AccountsMgmt().
+		V1().
+		Accounts().
+		List().
+		Parameter("fetchLabels", true).
+		Search(search)
 
 	collection = collection.Order(createQueryOrder(q))
 


### PR DESCRIPTION
In #59 we added support for labels, but we'll need to ensure the query to AMS actually pulls in the labels based on the API spec [1] where `fetchLabels=true` is required.

Note that we won't be able to test this until we have an account with labels applied, which OCM is assisting with.

[1] https://api.openshift.com/?urls.primaryName=Accounts%20management%20service#/default/get_api_accounts_mgmt_v1_accounts