### PR TITLE
Add debug flag

### DIFF
--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -125,6 +125,8 @@ objects:
             value: ${DISABLE_CATCHALL}
           - name: IS_INTERNAL_LABEL
             value: ${IS_INTERNAL_LABEL}
+          - name: DEBUG
+            value: ${DEBUG}
           image: quay.io/cloudservices/mbop:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           name: mbop
@@ -221,3 +223,6 @@ parameters:
 - name: IS_INTERNAL_LABEL
   description: OCM label to inform whether or not an account is internal
   value: ""
+- name: DEBUG
+  description: Debug flag
+  value: "false"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type MbopConfig struct {
 	PublicKey              string
 	DisableCatchall        bool
 	IsInternalLabel        string
+	Debug                  bool
 
 	StoreBackend     string
 	DatabaseHost     string
@@ -38,6 +39,7 @@ func Get() *MbopConfig {
 	}
 
 	disableCatchAll, _ := strconv.ParseBool(fetchWithDefault("DISABLE_CATCHALL", "false"))
+	debug, _ := strconv.ParseBool(fetchWithDefault("DEBUG", "false"))
 
 	c := &MbopConfig{
 		UsersModule:     fetchWithDefault("USERS_MODULE", ""),
@@ -63,6 +65,7 @@ func Get() *MbopConfig {
 		PrivateKey:             fetchWithDefault("TOKEN_PRIVATE_KEY", ""),
 		PublicKey:              fetchWithDefault("TOKEN_PUBLIC_KEY", ""),
 		IsInternalLabel:        fetchWithDefault("IS_INTERNAL_LABEL", ""),
+		Debug:                  debug,
 	}
 
 	conf = c

--- a/internal/service/ocm/ocm_impl.go
+++ b/internal/service/ocm/ocm_impl.go
@@ -20,7 +20,7 @@ type SDK struct {
 func (ocm *SDK) InitSdkConnection(ctx context.Context) error {
 	// Create a logger that has the debug level enabled:
 	logger, err := logging.NewGoLoggerBuilder().
-		Debug(true).
+		Debug(config.Get().Debug).
 		Build()
 
 	if err != nil {


### PR DESCRIPTION
[Add DEBUG flag to config](https://github.com/RedHatInsights/mbop/commit/06372a990b105625e85df962d29e46d3f1a43ffd) 

By default, `DEBUG` will be set to `false`. This can be enabled by setting:
`DEBUG: true` as a param in the environment (or `DEBUG=true` when running locally).

This surfaces the settings in the application config as well, via: `config.Get().Debug`

----

[Use debug flag in OCM logger to not enable by default](https://github.com/RedHatInsights/mbop/commit/39a4487513a7f08886407cef93e8df5530b4fe4c)