### PR TITLE
Update internal user mock for OCM/AMS

### DIFF
--- a/internal/service/ocm/ocm_mock.go
+++ b/internal/service/ocm/ocm_mock.go
@@ -29,11 +29,6 @@ func (ocm *SDKMock) GetUsers(u models.UserBody, q models.UserV1Query) (models.Us
 	}
 
 	for _, user := range u.Users {
-		orgID, err := rand.Int(rand.Reader, big.NewInt(999999-100000))
-		if err != nil {
-			return users, err
-		}
-
 		displayNameNum, err := rand.Int(rand.Reader, big.NewInt(99-0))
 		if err != nil {
 			return users, err
@@ -49,7 +44,7 @@ func (ocm *SDKMock) GetUsers(u models.UserBody, q models.UserV1Query) (models.Us
 			IsActive:      true,
 			IsInternal:    false,
 			Locale:        "en_US",
-			OrgID:         strconv.Itoa(int(orgID.Int64())),
+			OrgID:         user,
 			DisplayName:   "FedRAMP" + strconv.Itoa(int(displayNameNum.Int64())),
 			Type:          "User",
 		})


### PR DESCRIPTION
Having a dynamic `org_id` means that it can cause mismatches in looking up registrations when mocks are being used, since that `org_id` value is not static.

This just sets it to the username, since we only really care that it's a string value. This will ensure at least per username, the org will be the same.