### PR TITLE
Fix `is_internal` assignment

### DIFF
--- a/internal/service/ocm/ocm_impl.go
+++ b/internal/service/ocm/ocm_impl.go
@@ -152,7 +152,9 @@ func (ocm *SDK) CloseSdkConnection() {
 func getIsInternal(user *v1.Account) bool {
 	labels := user.Labels()
 	for _, l := range labels {
-		if l.Value() == config.Get().IsInternalLabel {
+		labelExists := l.Key() == config.Get().IsInternalLabel
+		labelTruthy := l.Value() == "true"
+		if labelExists && labelTruthy {
 			return true
 		}
 	}

--- a/internal/service/ocm/ocm_impl_test.go
+++ b/internal/service/ocm/ocm_impl_test.go
@@ -16,7 +16,7 @@ type OcmImplTestSuite struct {
 }
 
 func (suite *OcmImplTestSuite) SetupSuite() {
-	suite.IsInternalLabel = "foo"
+	suite.IsInternalLabel = "internalLabelKey"
 }
 
 func (suite *OcmImplTestSuite) SetupTest() {
@@ -24,9 +24,10 @@ func (suite *OcmImplTestSuite) SetupTest() {
 }
 
 func (suite *OcmImplTestSuite) TestGetIsInternalMatch() {
-	os.Setenv("IS_INTERNAL_LABEL", "foo")
+	os.Setenv("IS_INTERNAL_LABEL", "internalLabelKey")
 	l := &v1.LabelBuilder{}
-	l.Value(suite.IsInternalLabel)
+	l.Key(suite.IsInternalLabel)
+	l.Value("true")
 	acctB := &v1.AccountBuilder{}
 	acctB.Labels(l)
 	acct, _ := acctB.Build()
@@ -34,16 +35,28 @@ func (suite *OcmImplTestSuite) TestGetIsInternalMatch() {
 }
 
 func (suite *OcmImplTestSuite) TestGetIsInternaEmptyLabels() {
-	os.Setenv("IS_INTERNAL_LABEL", "foo")
+	os.Setenv("IS_INTERNAL_LABEL", "internalLabelKey")
 	acctB := &v1.AccountBuilder{}
 	acct, _ := acctB.Build()
 	suite.Equal(false, getIsInternal(acct))
 }
 
-func (suite *OcmImplTestSuite) TestGetIsInternalNoMatch() {
-	os.Setenv("IS_INTERNAL_LABEL", "bar")
+func (suite *OcmImplTestSuite) TestGetIsInternalNoKeyMatch() {
+	os.Setenv("IS_INTERNAL_LABEL", "foo")
 	l := &v1.LabelBuilder{}
-	l.Value(suite.IsInternalLabel)
+	l.Key(suite.IsInternalLabel)
+	l.Value("true")
+	acctB := &v1.AccountBuilder{}
+	acctB.Labels(l)
+	acct, _ := acctB.Build()
+	suite.Equal(false, getIsInternal(acct))
+}
+
+func (suite *OcmImplTestSuite) TestGetIsInternalNoValMatch() {
+	os.Setenv("IS_INTERNAL_LABEL", "internalLabelKey")
+	l := &v1.LabelBuilder{}
+	l.Key(suite.IsInternalLabel)
+	l.Value("false")
 	acctB := &v1.AccountBuilder{}
 	acctB.Labels(l)
 	acct, _ := acctB.Build()


### PR DESCRIPTION
We recently were able to configure test accounts with the labels we expect in a deployed environment, and that requires tweaking our expectations on the label object checks a bit.

The `Key()` of a label is the actual label name we reference, where the `Value()` we've set as the truthiness of this internal label. Though we'll likely only ever apply this label with a `"true"` value, we should still add an explicit check on the key and the value, vs just the existence of the environmental key.