### PR TITLE
Improve error messages on existing registrations

### DIFF
--- a/internal/handlers/registration_handler.go
+++ b/internal/handlers/registration_handler.go
@@ -116,20 +116,14 @@ func RegistrationCreateHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	db := store.GetStore()
-	_, err = db.Find(id.Identity.OrgID, *body.UID)
-	if err == nil {
-		doError(w, "existing registration found", 409)
-		return
-	}
-
 	_, err = db.Create(&store.Registration{
 		OrgID:       id.Identity.OrgID,
 		UID:         *body.UID,
 		DisplayName: *body.DisplayName,
 	})
 	if err != nil {
-		if errors.Is(err, store.ErrRegistrationAlreadyExists) {
-			doError(w, "existing registration found", 409)
+		if errors.Is(err, store.ErrRegistrationAlreadyExists{}) {
+			doError(w, err.Error(), 409)
 		} else {
 			do500(w, "failed to create registration: "+err.Error())
 		}

--- a/internal/handlers/registration_handler_test.go
+++ b/internal/handlers/registration_handler_test.go
@@ -163,7 +163,7 @@ func (suite *RegistrationTestSuite) TestExistingRegistrationCreate() {
 
 	status, rspBody := statusAndBodyFromReq(suite)
 	suite.Equal(http.StatusConflict, status)
-	suite.Equal("{\"message\":\"existing registration found\"}", rspBody)
+	suite.Equal("{\"message\":\"existing registration found: uid already exists\"}", rspBody)
 }
 
 func (suite *RegistrationTestSuite) TestExistingUidCreate() {
@@ -182,7 +182,7 @@ func (suite *RegistrationTestSuite) TestExistingUidCreate() {
 
 	status, rspBody := statusAndBodyFromReq(suite)
 	suite.Equal(http.StatusConflict, status)
-	suite.Equal("{\"message\":\"existing registration found\"}", rspBody)
+	suite.Equal("{\"message\":\"existing registration found: uid already exists\"}", rspBody)
 }
 
 func (suite *RegistrationTestSuite) TestSuccessfulRegistrationCreate() {

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -1,0 +1,24 @@
+package store
+
+import (
+	"errors"
+	"reflect"
+)
+
+var ErrRegistrationNotFound = errors.New("registration not found")
+
+// error type containing information on why a registration already exists
+type ErrRegistrationAlreadyExists struct {
+	Detail string
+}
+
+// satisfying the error interface
+func (e ErrRegistrationAlreadyExists) Error() string {
+	return "existing registration found: " + e.Detail
+}
+
+// implementing Is comparision so we can tell whether or not an error is this
+// instance type or not instead of just basing it on the error message itself
+func (e ErrRegistrationAlreadyExists) Is(err error) bool {
+	return reflect.TypeOf(err) == reflect.TypeOf(e)
+}

--- a/internal/store/in_memory_store_impl.go
+++ b/internal/store/in_memory_store_impl.go
@@ -37,17 +37,12 @@ func (m *inMemoryStore) FindByUID(uid string) (*Registration, error) {
 }
 
 func (m *inMemoryStore) Create(r *Registration) (string, error) {
-	x, _ := m.Find(r.OrgID, r.UID)
-	if x != nil {
-		return "", ErrRegistrationAlreadyExists
-	}
-
 	for i := range m.db {
 		if m.db[i].UID == r.UID {
-			return "", ErrRegistrationAlreadyExists
+			return "", ErrRegistrationAlreadyExists{Detail: "uid already exists"}
 		}
 		if m.db[i].DisplayName == r.DisplayName {
-			return "", ErrRegistrationAlreadyExists
+			return "", ErrRegistrationAlreadyExists{Detail: "display_name already exists"}
 		}
 	}
 

--- a/internal/store/postgres_store_impl.go
+++ b/internal/store/postgres_store_impl.go
@@ -80,7 +80,7 @@ func (p *postgresStore) Create(r *Registration) (string, error) {
 		// constraint violation == 23505
 		if errors.As(err, &pgErr) {
 			if pgErr.Code == "23505" {
-				return "", ErrRegistrationAlreadyExists
+				return "", ErrRegistrationAlreadyExists{Detail: pgErr.Detail}
 			}
 		} else {
 			return "", err

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 
 	"github.com/redhatinsights/mbop/internal/config"
@@ -14,11 +13,6 @@ var GetStore func() Store
 
 // persistent ref to an in-memory store if present
 var mem Store
-
-var (
-	ErrRegistrationAlreadyExists = errors.New("registration already exists")
-	ErrRegistrationNotFound      = errors.New("registration not found")
-)
 
 func SetupStore() error {
 	switch config.Get().StoreBackend {


### PR DESCRIPTION
notable changes:
- moved error type definitions to their own file, `errors.go`
- implemented custom struct to store a bit of info about what postgres spit back at us