### PR TITLE
Add support for listening on SSL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ all: build
 build:
 	go build cmd/mbop/mbop.go
 
+run:
+	go run cmd/mbop/mbop.go
+
 clean:
 	rm -f mbop
 	go clean -cache
@@ -16,4 +19,4 @@ lint:
 fix:
 	golangci-lint run --enable=errcheck,gocritic,gofmt,goimports,gosec,gosimple,govet,ineffassign,revive,staticcheck,typecheck,unused,bodyclose --fix=true --max-same-issues=20  --print-issued-lines=true --print-linter-name=true --sort-results=true
 
-.PHONY: build clean lint fix test
+.PHONY: build clean lint fix test run

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -149,9 +149,21 @@ objects:
             limits:
               cpu: ${CPU_LIMIT}
               memory: ${MEMORY_LIMIT}
+          volumeMounts:
+          - name: envoy-tls
+            readOnly: true
+            mountPath: /certs
+        volumes:
+        - name: envoy-tls
+          secret:
+            secretName: mbop-serving-cert
+            defaultMode: 420
+            optional: true
 - apiVersion: v1
   kind: Service
   metadata:
+    annotations:
+      service.beta.openshift.io/serving-cert-secret-name: mbop-serving-cert
     labels:
       app: mbop
     name: mbop
@@ -163,9 +175,16 @@ objects:
       port: ${{PORT}}
       protocol: TCP
       targetPort: ${{PORT}}
+    - name: tls
+      port: ${{TLS_PORT}}
+      protocol: TCP
+      targetPort: ${{TLS_PORT}}
 parameters:
 - name: PORT
   description: Port the application will listen on
+  value: "8090"
+- name: TLS_PORT
+  description: Port the application will listen on if using TLS
   value: "8090"
 - name: REPLICAS
   description: The number of replicas to use in the deployment
@@ -237,3 +256,6 @@ parameters:
 - name: DEBUG
   description: Debug flag
   value: "false"
+- name: CERT_DIR
+  description: the base directory where ssl certs are stored
+  value: "/certs"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,10 @@ type MbopConfig struct {
 	DatabaseUser     string
 	DatabasePassword string
 	DatabaseName     string
+
+	Port    string
+	UseTLS  bool
+	CertDir string
 }
 
 var conf *MbopConfig
@@ -44,6 +48,20 @@ func Get() *MbopConfig {
 
 	disableCatchAll, _ := strconv.ParseBool(fetchWithDefault("DISABLE_CATCHALL", "false"))
 	debug, _ := strconv.ParseBool(fetchWithDefault("DEBUG", "false"))
+	certDir := fetchWithDefault("CERT_DIR", "/certs")
+
+	var port string
+	var tls bool
+	_, err := os.Stat(certDir + "/tls.crt")
+	if err != nil {
+		// we're just running plain HTTP
+		port = fetchWithDefault("PORT", "8090")
+	} else {
+		// ..otherwise, if the err is nil - we have a cert. lets get set up for
+		// TLS
+		port = fetchWithDefault("TLS_PORT", "8090")
+		tls = true
+	}
 
 	c := &MbopConfig{
 		UsersModule:     fetchWithDefault("USERS_MODULE", ""),
@@ -74,6 +92,10 @@ func Get() *MbopConfig {
 		PublicKey:              fetchWithDefault("TOKEN_PUBLIC_KEY", ""),
 		IsInternalLabel:        fetchWithDefault("IS_INTERNAL_LABEL", ""),
 		Debug:                  debug,
+
+		Port:    port,
+		UseTLS:  tls,
+		CertDir: certDir,
 	}
 
 	conf = c


### PR DESCRIPTION
Just getting MBOP ready to listen on TLS for various environments where that is required.

Changes:
- Added `make run` command
- Added configuration options for `CERT_DIR` to tell it where certs live, `TLS_PORT` to say where to listen if we wanted the secure port to be different than the regular port
- ...and then just check if we have certs available and listen via HTTPS if necessary

NEAT