### PR TITLE
Adds support for Keycloak JWT module

### DIFF
--- a/internal/handlers/constants.go
+++ b/internal/handlers/constants.go
@@ -8,6 +8,7 @@ const awsModule = "aws"
 const amsModule = "ams"
 const mockModule = "mock"
 const printModule = "print"
+const keycloakModule = "keycloak"
 
 const defaultLimit = 100
 const defaultOffset = 0

--- a/internal/handlers/jwt_v1_handler.go
+++ b/internal/handlers/jwt_v1_handler.go
@@ -18,7 +18,7 @@ type JWTResp struct {
 
 func JWTV1Handler(w http.ResponseWriter, r *http.Request) {
 	switch config.Get().JwtModule {
-	case awsModule:
+	case awsModule, keycloakModule:
 		kid := r.URL.Query().Get("kid")
 		if kid == "" {
 			do400(w, "kid required to return correct pub key")


### PR DESCRIPTION
Since Keycloak and Cognito follow the JWK standard [1], we can reuse the same logic as defined in the `awsModule`. For the sake of being explicit, this adds another module `keycloakModule`, so that in the future if any module-specific needs arise, we can easily break them out, and it will also make it clear which JWK/JWT verification backing is used in an environment.

To test this locally, start up Keycloak, and configure:
```
JWK_URL=http://localhost:8080/auth/realms/master/protocol/openid-connect/certs
JWT_MODULE=keycloak
```

Then visit the `JWK_URL` to get an example of a `kid` from one of the JWKs, and call the following with it as a query param:
```
curl http://localhost:8090/v1/jwt?kid=<kid-from-above>
```

[1] https://www.ietf.org/rfc/rfc7517.txt