### PR TITLE
Replace Keycloak_protocol with Keycloak_scheme

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,7 +27,7 @@ type MbopConfig struct {
 	IsInternalLabel        string
 	Debug                  bool
 
-	KeyCloakProtocol       string
+	KeyCloakScheme         string
 	KeyCloakHost           string
 	KeyCloakPort           string
 	KeyCloakTimeout        int64
@@ -99,7 +99,7 @@ func Get() *MbopConfig {
 
 		KeyCloakHost:           fetchWithDefault("KEYCLOAK_HOST", "localhost"),
 		KeyCloakPort:           fetchWithDefault("KEYCLOAK_PORT", "8000"),
-		KeyCloakProtocol:       fetchWithDefault("KEYCLOAK_PROTOCOL", "http"),
+		KeyCloakScheme:         fetchWithDefault("KEYCLOAK_SCHEME", "http"),
 		KeyCloakTimeout:        keyCloakTimeout,
 		KeyCloakTokenUsername:  fetchWithDefault("KEYCLOAK_TOKEN_USERNAME", "admin"),
 		KeyCloakTokenPassword:  fetchWithDefault("KEYCLOAK_TOKEN_PASSWORD", "admin"),

--- a/internal/service/keycloak/keycloak.go
+++ b/internal/service/keycloak/keycloak.go
@@ -139,7 +139,7 @@ func createEncodedTokenBody() *strings.Reader {
 }
 
 func createTokenURL() (*url.URL, error) {
-	url, err := url.Parse(fmt.Sprintf("%s://%s:%s/token", config.Get().KeyCloakProtocol, config.Get().KeyCloakHost, config.Get().KeyCloakPort))
+	url, err := url.Parse(fmt.Sprintf("%s://%s:%s/token", config.Get().KeyCloakScheme, config.Get().KeyCloakHost, config.Get().KeyCloakPort))
 	if err != nil {
 		return nil, fmt.Errorf("error creating keycloak token url: %s", err)
 	}
@@ -149,7 +149,7 @@ func createTokenURL() (*url.URL, error) {
 
 // MAKE response to users function to massage data back to regular format
 func createV1RequestURL(usernames models.UserBody, q models.UserV1Query) (*url.URL, error) {
-	url, err := url.Parse(fmt.Sprintf("%s://%s:%s/users?limit=100", config.Get().KeyCloakProtocol, config.Get().KeyCloakHost, config.Get().KeyCloakPort))
+	url, err := url.Parse(fmt.Sprintf("%s://%s:%s/users?limit=100", config.Get().KeyCloakScheme, config.Get().KeyCloakHost, config.Get().KeyCloakPort))
 	if err != nil {
 		return nil, fmt.Errorf("error creating (keycloak) /users url: %s", err)
 	}
@@ -171,7 +171,7 @@ func createV1RequestURL(usernames models.UserBody, q models.UserV1Query) (*url.U
 }
 
 func createV3UsersRequestURL(orgID string, q models.UserV3Query) (*url.URL, error) {
-	url, err := url.Parse(fmt.Sprintf("%s://%s:%s/users", config.Get().KeyCloakProtocol, config.Get().KeyCloakHost, config.Get().KeyCloakPort))
+	url, err := url.Parse(fmt.Sprintf("%s://%s:%s/users", config.Get().KeyCloakScheme, config.Get().KeyCloakHost, config.Get().KeyCloakPort))
 	if err != nil {
 		return nil, fmt.Errorf("error creating (keycloak) /v3/users url: %s", err)
 	}


### PR DESCRIPTION
Due to the fact that KEYCLOAK_SCHEME already exists in the deployment template, replace the previously defined keycloak_protocol with the KEYCLOAK_SCHEME variable.