### PR TITLE
Keycloak v3 user endpoint fixes

### DIFF
--- a/internal/handlers/accounts_v3_usersBy_handler.go
+++ b/internal/handlers/accounts_v3_usersBy_handler.go
@@ -144,7 +144,7 @@ func AccountsV3UsersByHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		sendJSON(w, usersToV3Response(u.Users))
+		sendJSON(w, u.Users) // usersToV3Response()
 	default:
 		// mbop server instance injected somewhere
 		// pass right through to the current handler

--- a/internal/handlers/accounts_v3_usersBy_handler.go
+++ b/internal/handlers/accounts_v3_usersBy_handler.go
@@ -144,7 +144,7 @@ func AccountsV3UsersByHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		sendJSON(w, u.Users) // usersToV3Response()
+		sendJSON(w, u.Users)
 	default:
 		// mbop server instance injected somewhere
 		// pass right through to the current handler

--- a/internal/service/keycloak-user-service/user_service.go
+++ b/internal/service/keycloak-user-service/user_service.go
@@ -128,8 +128,12 @@ func createV3UsersRequestURL(orgID string, q models.UserV3Query) (*url.URL, erro
 	}
 	queryParams := url.Query()
 
+	// default ordering
+	queryParams.Add("order", "username")
+	queryParams.Add("direction", "asc")
+
 	if q.SortOrder != "" {
-		queryParams.Add("direction", q.SortOrder)
+		queryParams.Set("direction", q.SortOrder)
 	}
 
 	queryParams.Add("org_id", orgID)


### PR DESCRIPTION
[The user response for v3 usersBy should just return the users](https://github.com/RedHatInsights/mbop/pull/90/commits/0d8e6b28b21a4ec2287cee411f299c4633a0079a)

[Add default ordering direction and order by](https://github.com/RedHatInsights/mbop/pull/90/commits/e24b33bd78b8c71c6480ae16b8ac52b99d6e202b) 
Currently the UI implicitly assumes that the only field which can be ordered in
bop/mbop is `username`, so it's not explicitly passed in an `orderBy` param.

This will default to use `username` as the default order field for keycloak, and
also defaults the direction to `asc`, as the keycloak user service defaults to `desc`.

Once the UI supports multiple ordering fields, we'll need to adjust the supported
`orderBy` fields in the v3 endpoints and translate them for keycloak.