### PR TITLE
RHCLOUD-26904 | fix: sendJSONWithStatusCode missing Content Type header

### DIFF
--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -26,6 +26,8 @@ func sendJSON(w http.ResponseWriter, data any) {
 func sendJSONWithStatusCode(w http.ResponseWriter, data any, code int) {
 	b, _ := json.Marshal(data)
 
+	w.Header().Set("Content-Type", "application/json")
+
 	w.WriteHeader(code)
 	_, err := w.Write(b)
 	if err != nil {

--- a/internal/handlers/helpers_test.go
+++ b/internal/handlers/helpers_test.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/redhatinsights/mbop/internal/config"
+)
+
+// defaultUsersModule holds the default users module set by the configuration.
+var defaultUsersModule = config.Get().UsersModule
+
+// cleanup reverts the "users module" to the one that was present before running the tests.
+func cleanup() {
+	config.Get().UsersModule = defaultUsersModule
+}
+
+// TestSendJSONWithStatusCodeContentTypeHeader tests that the helper function returns an "application/json" value for
+// the "Content-Type" header.
+func TestSendJSONWithStatusCodeContentTypeHeader(t *testing.T) {
+	defer cleanup()
+
+	config.Get().UsersModule = "mock"
+
+	testRouter := chi.NewRouter()
+	testRouter.Get("/v3/accounts/{orgID}/users", AccountsV3UsersHandler)
+
+	testServer := httptest.NewServer(testRouter)
+	defer testServer.Close()
+
+	fullURL := fmt.Sprintf("%s/v3/accounts/12345/users", testServer.URL)
+	response, err := http.Get(fullURL) // nolint because the test server's URL is dynamic.
+	if err != nil {
+		t.Errorf(`unable to send request to the "AccountsV3UsersHandler" endpoint: %s`, err)
+	}
+
+	defer response.Body.Close()
+
+	if response.StatusCode != 200 {
+		t.Errorf(`unexpected status code received. Want "%d", got "%d"`, 200, response.StatusCode)
+	}
+
+	if response.Header.Get("Content-Type") != "application/json" {
+		t.Errorf(`unexpected "Content-Type" header received. Want "%s", got "%s"`, "application/json", response.Header.Get("Content-Type"))
+	}
+}


### PR DESCRIPTION
The "sendJSONWithStatusCode" function was sending a "text/plain" value for the "Content-Type" header by default, instead of the "application/json" value that users might expect when calling the endpoint.

## Links

[[RHCLOUD-26904]](https://issues.redhat.com/browse/RHCLOUD-26904)