### PR TITLE
fix bug where we dropped support for 'system' blocks that are going to be imported

### DIFF
--- a/internal/store/postgres_store_impl.go
+++ b/internal/store/postgres_store_impl.go
@@ -176,9 +176,9 @@ func (p *postgresStore) AllowedIP(ip string, orgID string) (bool, error) {
 	// turns out postgres can do this on the backend! see old code that accomplishes the same thing at commit dca8f2c
 
 	// basically its doing a subquery selecting all blocks from the org or
-	// gateway and then shoving them into an array and checking if the ip exists
-	// in those blocks.
-	row := p.db.QueryRow(`select $1::inet << any(array(select ip_block from allowlist where org_id = $2)::inet[])`, ip, orgID)
+	// 'system' (old hardcoded ones) and then shoving them into an array and
+	// checking if the ip exists in those blocks.
+	row := p.db.QueryRow(`select $1::inet << any(array(select ip_block from allowlist where org_id = $2 or org_id = 'system')::inet[])`, ip, orgID)
 
 	var valid bool
 	err := row.Scan(&valid)

--- a/internal/store/postgres_store_impl_test.go
+++ b/internal/store/postgres_store_impl_test.go
@@ -294,3 +294,25 @@ func (suite *TestSuite) TestIPAllowedHappyMultiple() {
 		suite.Nil(err)
 	}
 }
+
+func (suite *TestSuite) TestIPAllowedWithSystem() {
+	config.Reset()
+	defer config.Reset()
+	os.Setenv("ALLOWLIST_ENABLED", "true")
+	defer os.Setenv("ALLOWLIST_ENABLED", "false")
+
+	suite.Nil(suite.store.AllowAddress(&AllowlistBlock{
+		IPBlock: "10.0.0.1/24",
+		OrgID:   "1234",
+	}))
+	suite.Nil(suite.store.AllowAddress(&AllowlistBlock{
+		IPBlock: "192.168.1.1/24",
+		OrgID:   "system",
+	}))
+
+	for _, ip := range []string{"10.0.0.100", "192.168.1.100", "10.0.0.20/32", "192.168.1.20/32"} {
+		allowed, err := suite.store.AllowedIP(ip, "1234")
+		suite.True(allowed)
+		suite.Nil(err)
+	}
+}


### PR DESCRIPTION
Basically we need a way to import all of the current IPs from the gateway into a "global" list - this prevents us from having to insert these manually with a dummy header or tied to specific org_ids (e.g. if the test org_id changes). 