### PR TITLE
[RHCLOUD-36506] upgrade the base image ubi8/go-toolset to the latest version

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -23,9 +23,9 @@ jobs:
 
     steps:
       - uses: actions/setup-go@v5
-        name: Set up golang 1.21
+        name: Set up golang 1.22
         with:
-          go-version: '1.21.13'
+          go-version: '1.22.10'
       - name: Check out source code
         uses: actions/checkout@v4
       - name: Run Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.21.13-1.1727869850 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.22.7-5.1731464728 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhatinsights/mbop
 
-go 1.21
+go 1.22
 
 require (
 	github.com/RedHatInsights/jwk2pem v0.0.0-20230131125756-f780f7dad7d8


### PR DESCRIPTION
[RHCLOUD-36506](https://issues.redhat.com/browse/RHCLOUD-36506)

ubi8/go-toolset base image https://catalog.redhat.com/software/containers/ubi8/go-toolset/5ce8713aac3db925c03774d1

this will fix few vulnerabilities in the ConsoleDot Platform Security Scan, e.g. https://github.com/RedHatInsights/mbop/actions/runs/12051229563
