### PR TITLE
[RHCLOUD-36523] upgrade to the go 1.19

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-go@v5
         name: Set up Go 1.x
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - uses: actions/checkout@v4
         name: Checkout mbop

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -23,9 +23,9 @@ jobs:
 
     steps:
       - uses: actions/setup-go@v5
-        name: Set up golang 1.18
+        name: Set up golang 1.19
         with:
-          go-version: '1.18.4'
+          go-version: '1.19.13'
       - name: Check out source code
         uses: actions/checkout@v4
       - name: Run Tests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhatinsights/mbop
 
-go 1.18
+go 1.19
 
 require (
 	github.com/RedHatInsights/jwk2pem v0.0.0-20230131125756-f780f7dad7d8

--- a/internal/service/keycloak-user-service/user_service.go
+++ b/internal/service/keycloak-user-service/user_service.go
@@ -3,7 +3,7 @@ package keycloakuserservice
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -108,7 +108,7 @@ func (userService *UserServiceClient) sendKeycloakGetRequest(url *url.URL, token
 		return responseBody, err
 	}
 
-	responseBody, err = ioutil.ReadAll(resp.Body)
+	responseBody, err = io.ReadAll(resp.Body)
 	if err != nil {
 		l.Log.Error(err, "error reading keycloak response body")
 		return responseBody, err

--- a/internal/service/keycloak/keycloak.go
+++ b/internal/service/keycloak/keycloak.go
@@ -3,7 +3,7 @@ package keycloak
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -41,7 +41,7 @@ func (keycloak *Client) GetAccessToken() (string, error) {
 
 	defer resp.Body.Close()
 
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("error reading keycloak token response body: %s", err)
 	}


### PR DESCRIPTION
[RHCLOUD-36523](https://issues.redhat.com/browse/RHCLOUD-36523)

upgrade from 1.18 into 1.19
 
fix deprecation warnings for `ioutil.ReadAll`
https://pkg.go.dev/io/ioutil#ReadAll