### PR TITLE
[RHCLOUD-36974] update ubi8/go-toolset base image to the latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.22.7-5.1731464728 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.22.9-1 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
[RHCLOUD-36974](https://issues.redhat.com/browse/RHCLOUD-36974)