### PR TITLE
RHCLOUD-20981 [MBOP] Runtime error if Keycloak not available and a token is requested

### DIFF
--- a/internal/service/catchall/ephemeral.go
+++ b/internal/service/catchall/ephemeral.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"net"
 	"os"
 	"sort"
 	"strconv"
@@ -263,6 +264,11 @@ func (m *MBOPServer) usersV1(w http.ResponseWriter, r *http.Request) {
 	filt := &V1UserInput{}
 	data, err := io.ReadAll(r.Body)
 	if err != nil {
+		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+			fmt.Printf("\n\nRequest timed out: %s\n\n", err.Error())
+		} else {
+		fmt.Printf("\n\n%s\n\n", err.Error())
+		}
 		http.Error(w, "malformed input", http.StatusInternalServerError)
 		return
 	}
@@ -309,9 +315,13 @@ type usersSpec struct {
 func (m *MBOPServer) getUsers() (users []models.User, err error) {
 	resp, err := m.Client.Get(m.getURL("/auth/admin/realms/redhat-external/users", map[string]string{"max": "2000"}))
 	if err != nil {
+		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+			fmt.Printf("\n\nRequest timed out: %s\n\n", err.Error())
+		} else {
 		fmt.Printf("\n\n%s\n\n", err.Error())
 	}
-
+	}
+	
 	defer resp.Body.Close()
 
 	obj := &[]usersSpec{}

--- a/internal/service/catchall/ephemeral.go
+++ b/internal/service/catchall/ephemeral.go
@@ -179,7 +179,7 @@ func (m *MBOPServer) getJWT(realm string) (*JSONStruct, error) {
 	if resp != nil && resp.Body != nil {
 		defer resp.Body.Close()
 	} else {
-		fmt.Println("Recieved an empty response from the keycloak server.")
+		fmt.Println("Received an empty response from the keycloak server.")
 		return nil, err
 	}
 
@@ -246,7 +246,7 @@ func (m *MBOPServer) getUser(_ http.ResponseWriter, r *http.Request) (*models.Us
 	if resp != nil && resp.Body != nil {
 		defer resp.Body.Close()
 	} else {
-		fmt.Println("Recieved an empty response from the keycloak server.")
+		fmt.Println("Received an empty response from the keycloak server.")
 		return nil, err
 	}
 
@@ -361,7 +361,7 @@ func (m *MBOPServer) getUsers() (users []models.User, err error) {
 	if resp != nil && resp.Body != nil {
 		defer resp.Body.Close()
 	} else {
-		fmt.Println("Recieved an empty response from the keycloak server.")
+		fmt.Println("Received an empty response from the keycloak server.")
 		return nil, err
 	}
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-20981

Gracefully handle errors when a token is requested from keycloak but the server cannot be reached or is down.