### PR TITLE
task: update user struct to support user count

### DIFF
--- a/internal/handlers/accounts_v3_usersBy_handler.go
+++ b/internal/handlers/accounts_v3_usersBy_handler.go
@@ -144,7 +144,7 @@ func AccountsV3UsersByHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		sendJSON(w, u.Users)
+		sendJSON(w, u)
 	default:
 		// mbop server instance injected somewhere
 		// pass right through to the current handler

--- a/internal/handlers/accounts_v3_users_handler.go
+++ b/internal/handlers/accounts_v3_users_handler.go
@@ -121,7 +121,7 @@ func AccountsV3UsersHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		sendJSON(w, u.Users) // usersToV3Response()
+		sendJSON(w, u) // usersToV3Response()
 	default:
 		// mbop server instance injected somewhere
 		// pass right through to the current handler

--- a/internal/handlers/users_v1_handler.go
+++ b/internal/handlers/users_v1_handler.go
@@ -108,7 +108,7 @@ func UsersV1Handler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		sendJSON(w, u.Users)
+		sendJSON(w, u)
 		return
 	default:
 		// mbop server instance injected somewhere

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -1,7 +1,8 @@
 package models
 
 type Users struct {
-	Users []User `json:"users,omitempty"`
+	UserCount int    `json:"userCount,omitempty"`
+	Users     []User `json:"users,omitempty"`
 }
 
 type UserV3Responses struct {

--- a/internal/service/keycloak-user-service/user_service.go
+++ b/internal/service/keycloak-user-service/user_service.go
@@ -45,7 +45,7 @@ func (userService *UserServiceClient) GetUsers(token string, u models.UserBody, 
 		return users, err
 	}
 
-	return keycloakResponseToUsers(unmarshaledResponse.Users), err
+	return keycloakResponseToUsers(unmarshaledResponse), err
 }
 
 func (userService *UserServiceClient) GetAccountV3Users(orgID string, token string, q models.UserV3Query) (models.Users, error) {
@@ -67,7 +67,7 @@ func (userService *UserServiceClient) GetAccountV3Users(orgID string, token stri
 		return users, err
 	}
 
-	return keycloakResponseToUsers(unmarshaledResponse.Users), nil
+	return keycloakResponseToUsers(unmarshaledResponse), nil
 }
 
 func (userService *UserServiceClient) GetAccountV3UsersBy(orgID string, token string, q models.UserV3Query, usersByBody models.UsersByBody) (models.Users, error) {
@@ -89,7 +89,7 @@ func (userService *UserServiceClient) GetAccountV3UsersBy(orgID string, token st
 		return users, err
 	}
 
-	return keycloakResponseToUsers(unmarshaledResponse.Users), nil
+	return keycloakResponseToUsers(unmarshaledResponse), nil
 }
 
 func (userService *UserServiceClient) sendKeycloakGetRequest(url *url.URL, token string) ([]byte, error) {
@@ -217,10 +217,10 @@ func createUsernamesQuery(usernames []string) string {
 	return usernameQuery
 }
 
-func keycloakResponseToUsers(r []models.KeycloakResponse) models.Users {
-	users := models.Users{Users: []models.User{}}
+func keycloakResponseToUsers(r models.KeycloakResponses) models.Users {
+	users := models.Users{UserCount: r.Meta.Total, Users: []models.User{}}
 
-	for _, response := range r {
+	for _, response := range r.Users {
 		users.AddUser(models.User{
 			Username:      response.Username,
 			ID:            response.ID,


### PR DESCRIPTION
Changes to the keycloak user service resulted in the full count of users not being sent forward to end services. This change sets the UserCount value for RBAC to read so that pagination works as expected.