### PR TITLE
fix: Fix single user returns

### DIFF
--- a/internal/handlers/accounts_v3_usersBy_handler.go
+++ b/internal/handlers/accounts_v3_usersBy_handler.go
@@ -144,6 +144,11 @@ func AccountsV3UsersByHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		if len(u.Users) == 1 {
+			sendJSON(w, u.Users[0])
+			return
+		}
+
 		sendJSON(w, u)
 	default:
 		// mbop server instance injected somewhere

--- a/internal/handlers/accounts_v3_usersBy_handler.go
+++ b/internal/handlers/accounts_v3_usersBy_handler.go
@@ -145,7 +145,7 @@ func AccountsV3UsersByHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if len(u.Users) == 1 {
-			sendJSON(w, u.Users)
+			sendJSON(w, u.Users[0])
 			return
 		}
 

--- a/internal/handlers/accounts_v3_usersBy_handler.go
+++ b/internal/handlers/accounts_v3_usersBy_handler.go
@@ -145,7 +145,7 @@ func AccountsV3UsersByHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if len(u.Users) == 1 {
-			sendJSON(w, u.Users[0])
+			sendJSON(w, u.Users)
 			return
 		}
 

--- a/internal/handlers/accounts_v3_users_handler.go
+++ b/internal/handlers/accounts_v3_users_handler.go
@@ -122,7 +122,7 @@ func AccountsV3UsersHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if len(u.Users) == 1 {
-			sendJSON(w, u.Users[0])
+			sendJSON(w, u.Users)
 			return
 		}
 

--- a/internal/handlers/accounts_v3_users_handler.go
+++ b/internal/handlers/accounts_v3_users_handler.go
@@ -122,11 +122,11 @@ func AccountsV3UsersHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if len(u.Users) == 1 {
-			sendJSON(w, u.Users)
+			sendJSON(w, u.Users[0])
 			return
 		}
 
-		sendJSON(w, u) // usersToV3Response()
+		sendJSON(w, u)
 	default:
 		// mbop server instance injected somewhere
 		// pass right through to the current handler

--- a/internal/handlers/accounts_v3_users_handler.go
+++ b/internal/handlers/accounts_v3_users_handler.go
@@ -121,6 +121,11 @@ func AccountsV3UsersHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		if len(u.Users) == 1 {
+			sendJSON(w, u.Users[0])
+			return
+		}
+
 		sendJSON(w, u) // usersToV3Response()
 	default:
 		// mbop server instance injected somewhere

--- a/internal/service/keycloak-user-service/user_service.go
+++ b/internal/service/keycloak-user-service/user_service.go
@@ -45,15 +45,7 @@ func (userService *UserServiceClient) GetUsers(token string, u models.UserBody, 
 		return users, err
 	}
 
-	result := keycloakResponseToUsers(unmarshaledResponse)
-	switch v := result.(type) {
-	case models.Users:
-		return v, nil
-	case []models.User:
-		return models.Users{Users: v}, nil
-	default:
-		return users, fmt.Errorf("unexpected response type from keycloakResponseToUsers")
-	}
+	return keycloakResponseToUsers(unmarshaledResponse), err
 }
 
 func (userService *UserServiceClient) GetAccountV3Users(orgID string, token string, q models.UserV3Query) (models.Users, error) {
@@ -75,15 +67,7 @@ func (userService *UserServiceClient) GetAccountV3Users(orgID string, token stri
 		return users, err
 	}
 
-	result := keycloakResponseToUsers(unmarshaledResponse)
-	switch v := result.(type) {
-	case models.Users:
-		return v, nil
-	case []models.User:
-		return models.Users{Users: v}, nil
-	default:
-		return users, fmt.Errorf("unexpected response type from keycloakResponseToUsers")
-	}
+	return keycloakResponseToUsers(unmarshaledResponse), err
 }
 
 func (userService *UserServiceClient) GetAccountV3UsersBy(orgID string, token string, q models.UserV3Query, usersByBody models.UsersByBody) (models.Users, error) {
@@ -105,15 +89,7 @@ func (userService *UserServiceClient) GetAccountV3UsersBy(orgID string, token st
 		return users, err
 	}
 
-	result := keycloakResponseToUsers(unmarshaledResponse)
-	switch v := result.(type) {
-	case models.Users:
-		return v, nil
-	case []models.User:
-		return models.Users{Users: v}, nil
-	default:
-		return users, fmt.Errorf("unexpected response type from keycloakResponseToUsers")
-	}
+	return keycloakResponseToUsers(unmarshaledResponse), err
 }
 
 func (userService *UserServiceClient) sendKeycloakGetRequest(url *url.URL, token string) ([]byte, error) {
@@ -241,28 +217,7 @@ func createUsernamesQuery(usernames []string) string {
 	return usernameQuery
 }
 
-func keycloakResponseToUsers(r models.KeycloakResponses) interface{} {
-	// If we have exactly one user, return just the array
-	if len(r.Users) == 1 {
-		user := r.Users[0]
-		return []models.User{{
-			Username:      user.Username,
-			ID:            user.ID,
-			Email:         user.Email,
-			FirstName:     user.FirstName,
-			LastName:      user.LastName,
-			AddressString: "",
-			IsActive:      user.IsActive,
-			IsInternal:    user.IsInternal,
-			Locale:        "en_US",
-			OrgID:         user.OrgID,
-			DisplayName:   user.UserID,
-			Type:          user.Type,
-			IsOrgAdmin:    user.IsOrgAdmin,
-		}}
-	}
-
-	// For multiple users, include the count
+func keycloakResponseToUsers(r models.KeycloakResponses) models.Users {
 	users := models.Users{UserCount: r.Meta.Total, Users: []models.User{}}
 
 	for _, response := range r.Users {

--- a/internal/service/keycloak-user-service/user_service.go
+++ b/internal/service/keycloak-user-service/user_service.go
@@ -218,6 +218,29 @@ func createUsernamesQuery(usernames []string) string {
 }
 
 func keycloakResponseToUsers(r models.KeycloakResponses) models.Users {
+	// If we have exactly one user, return just that user without the count
+	if len(r.Users) == 1 {
+		user := r.Users[0]
+		return models.Users{
+			Users: []models.User{{
+				Username:      user.Username,
+				ID:            user.ID,
+				Email:         user.Email,
+				FirstName:     user.FirstName,
+				LastName:      user.LastName,
+				AddressString: "",
+				IsActive:      user.IsActive,
+				IsInternal:    user.IsInternal,
+				Locale:        "en_US",
+				OrgID:         user.OrgID,
+				DisplayName:   user.UserID,
+				Type:          user.Type,
+				IsOrgAdmin:    user.IsOrgAdmin,
+			}},
+		}
+	}
+
+	// For multiple users, include the count
 	users := models.Users{UserCount: r.Meta.Total, Users: []models.User{}}
 
 	for _, response := range r.Users {

--- a/internal/service/keycloak-user-service/user_service.go
+++ b/internal/service/keycloak-user-service/user_service.go
@@ -45,7 +45,15 @@ func (userService *UserServiceClient) GetUsers(token string, u models.UserBody, 
 		return users, err
 	}
 
-	return keycloakResponseToUsers(unmarshaledResponse), err
+	result := keycloakResponseToUsers(unmarshaledResponse)
+	switch v := result.(type) {
+	case models.Users:
+		return v, nil
+	case []models.User:
+		return models.Users{Users: v}, nil
+	default:
+		return users, fmt.Errorf("unexpected response type from keycloakResponseToUsers")
+	}
 }
 
 func (userService *UserServiceClient) GetAccountV3Users(orgID string, token string, q models.UserV3Query) (models.Users, error) {
@@ -67,7 +75,15 @@ func (userService *UserServiceClient) GetAccountV3Users(orgID string, token stri
 		return users, err
 	}
 
-	return keycloakResponseToUsers(unmarshaledResponse), nil
+	result := keycloakResponseToUsers(unmarshaledResponse)
+	switch v := result.(type) {
+	case models.Users:
+		return v, nil
+	case []models.User:
+		return models.Users{Users: v}, nil
+	default:
+		return users, fmt.Errorf("unexpected response type from keycloakResponseToUsers")
+	}
 }
 
 func (userService *UserServiceClient) GetAccountV3UsersBy(orgID string, token string, q models.UserV3Query, usersByBody models.UsersByBody) (models.Users, error) {
@@ -89,7 +105,15 @@ func (userService *UserServiceClient) GetAccountV3UsersBy(orgID string, token st
 		return users, err
 	}
 
-	return keycloakResponseToUsers(unmarshaledResponse), nil
+	result := keycloakResponseToUsers(unmarshaledResponse)
+	switch v := result.(type) {
+	case models.Users:
+		return v, nil
+	case []models.User:
+		return models.Users{Users: v}, nil
+	default:
+		return users, fmt.Errorf("unexpected response type from keycloakResponseToUsers")
+	}
 }
 
 func (userService *UserServiceClient) sendKeycloakGetRequest(url *url.URL, token string) ([]byte, error) {
@@ -217,27 +241,25 @@ func createUsernamesQuery(usernames []string) string {
 	return usernameQuery
 }
 
-func keycloakResponseToUsers(r models.KeycloakResponses) models.Users {
-	// If we have exactly one user, return just that user without the count
+func keycloakResponseToUsers(r models.KeycloakResponses) interface{} {
+	// If we have exactly one user, return just the array
 	if len(r.Users) == 1 {
 		user := r.Users[0]
-		return models.Users{
-			Users: []models.User{{
-				Username:      user.Username,
-				ID:            user.ID,
-				Email:         user.Email,
-				FirstName:     user.FirstName,
-				LastName:      user.LastName,
-				AddressString: "",
-				IsActive:      user.IsActive,
-				IsInternal:    user.IsInternal,
-				Locale:        "en_US",
-				OrgID:         user.OrgID,
-				DisplayName:   user.UserID,
-				Type:          user.Type,
-				IsOrgAdmin:    user.IsOrgAdmin,
-			}},
-		}
+		return []models.User{{
+			Username:      user.Username,
+			ID:            user.ID,
+			Email:         user.Email,
+			FirstName:     user.FirstName,
+			LastName:      user.LastName,
+			AddressString: "",
+			IsActive:      user.IsActive,
+			IsInternal:    user.IsInternal,
+			Locale:        "en_US",
+			OrgID:         user.OrgID,
+			DisplayName:   user.UserID,
+			Type:          user.Type,
+			IsOrgAdmin:    user.IsOrgAdmin,
+		}}
 	}
 
 	// For multiple users, include the count

--- a/internal/service/keycloak-user-service/user_service.go
+++ b/internal/service/keycloak-user-service/user_service.go
@@ -67,7 +67,7 @@ func (userService *UserServiceClient) GetAccountV3Users(orgID string, token stri
 		return users, err
 	}
 
-	return keycloakResponseToUsers(unmarshaledResponse), err
+	return keycloakResponseToUsers(unmarshaledResponse), nil
 }
 
 func (userService *UserServiceClient) GetAccountV3UsersBy(orgID string, token string, q models.UserV3Query, usersByBody models.UsersByBody) (models.Users, error) {
@@ -89,7 +89,7 @@ func (userService *UserServiceClient) GetAccountV3UsersBy(orgID string, token st
 		return users, err
 	}
 
-	return keycloakResponseToUsers(unmarshaledResponse), err
+	return keycloakResponseToUsers(unmarshaledResponse), nil
 }
 
 func (userService *UserServiceClient) sendKeycloakGetRequest(url *url.URL, token string) ([]byte, error) {

--- a/internal/service/keycloak-user-service/user_service.go
+++ b/internal/service/keycloak-user-service/user_service.go
@@ -45,7 +45,15 @@ func (userService *UserServiceClient) GetUsers(token string, u models.UserBody, 
 		return users, err
 	}
 
-	return keycloakResponseToUsers(unmarshaledResponse), err
+	result := keycloakResponseToUsers(unmarshaledResponse)
+	switch v := result.(type) {
+	case models.Users:
+		return v, nil
+	case []models.User:
+		return models.Users{Users: v}, nil
+	default:
+		return users, fmt.Errorf("unexpected response type from keycloakResponseToUsers")
+	}
 }
 
 func (userService *UserServiceClient) GetAccountV3Users(orgID string, token string, q models.UserV3Query) (models.Users, error) {
@@ -67,7 +75,15 @@ func (userService *UserServiceClient) GetAccountV3Users(orgID string, token stri
 		return users, err
 	}
 
-	return keycloakResponseToUsers(unmarshaledResponse), nil
+	result := keycloakResponseToUsers(unmarshaledResponse)
+	switch v := result.(type) {
+	case models.Users:
+		return v, nil
+	case []models.User:
+		return models.Users{Users: v}, nil
+	default:
+		return users, fmt.Errorf("unexpected response type from keycloakResponseToUsers")
+	}
 }
 
 func (userService *UserServiceClient) GetAccountV3UsersBy(orgID string, token string, q models.UserV3Query, usersByBody models.UsersByBody) (models.Users, error) {
@@ -89,7 +105,15 @@ func (userService *UserServiceClient) GetAccountV3UsersBy(orgID string, token st
 		return users, err
 	}
 
-	return keycloakResponseToUsers(unmarshaledResponse), nil
+	result := keycloakResponseToUsers(unmarshaledResponse)
+	switch v := result.(type) {
+	case models.Users:
+		return v, nil
+	case []models.User:
+		return models.Users{Users: v}, nil
+	default:
+		return users, fmt.Errorf("unexpected response type from keycloakResponseToUsers")
+	}
 }
 
 func (userService *UserServiceClient) sendKeycloakGetRequest(url *url.URL, token string) ([]byte, error) {
@@ -217,7 +241,28 @@ func createUsernamesQuery(usernames []string) string {
 	return usernameQuery
 }
 
-func keycloakResponseToUsers(r models.KeycloakResponses) models.Users {
+func keycloakResponseToUsers(r models.KeycloakResponses) interface{} {
+	// If we have exactly one user, return just the array
+	if len(r.Users) == 1 {
+		user := r.Users[0]
+		return []models.User{{
+			Username:      user.Username,
+			ID:            user.ID,
+			Email:         user.Email,
+			FirstName:     user.FirstName,
+			LastName:      user.LastName,
+			AddressString: "",
+			IsActive:      user.IsActive,
+			IsInternal:    user.IsInternal,
+			Locale:        "en_US",
+			OrgID:         user.OrgID,
+			DisplayName:   user.UserID,
+			Type:          user.Type,
+			IsOrgAdmin:    user.IsOrgAdmin,
+		}}
+	}
+
+	// For multiple users, include the count
 	users := models.Users{UserCount: r.Meta.Total, Users: []models.User{}}
 
 	for _, response := range r.Users {


### PR DESCRIPTION
RBAC is looking for a simple data structure rather than a dictionary when you click a single email and want that users details. This fix ensure that we only send the user array and no userCount if the lenght of the array is 1.