### PR TITLE
Fix single user view in rbac

### DIFF
--- a/internal/handlers/accounts_v3_users_handler.go
+++ b/internal/handlers/accounts_v3_users_handler.go
@@ -121,6 +121,11 @@ func AccountsV3UsersHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		if u.UserCount == 1 {
+			sendJSON(w, u.Users)
+			return
+		}
+
 		sendJSON(w, u) // usersToV3Response()
 	default:
 		// mbop server instance injected somewhere

--- a/internal/handlers/users_v1_handler.go
+++ b/internal/handlers/users_v1_handler.go
@@ -108,6 +108,11 @@ func UsersV1Handler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		if u.UserCount == 1 {
+			sendJSON(w, u.Users)
+			return
+		}
+
 		sendJSON(w, u)
 		return
 	default:


### PR DESCRIPTION
If we only have a single user, we should just return that single user. This is meant to fix an issue when viewing one user at a time rather than the table. It should just emulate what we did before fixing the pagination problem.