### PR TITLE
switch from chi routing to new stdlib matchers

### DIFF
--- a/cmd/mbop/mbop.go
+++ b/cmd/mbop/mbop.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/redhatinsights/mbop/internal/service/mailer"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/redhatinsights/mbop/internal/handlers"
 	l "github.com/redhatinsights/mbop/internal/logger"
 	"github.com/redhatinsights/mbop/internal/middleware"
@@ -29,33 +29,33 @@ func main() {
 		panic(err)
 	}
 
-	r := chi.NewRouter()
-	// Emulating the log message at the beginning of mainHandler()
-	r.Use(middleware.Logging)
+	mux := http.NewServeMux()
 
-	// TODO: move these to actual handler functions as we figure out which paths
-	// are get vs post
-	r.Get("/", handlers.Status)
-	r.Get("/v*", handlers.CatchAll)
-	r.Post("/v*", handlers.CatchAll)
-	r.Get("/api/entitlements*", handlers.CatchAll)
-	r.Get("/v1/jwt", handlers.JWTV1Handler)
-	r.Post("/v1/users", handlers.UsersV1Handler)
-	r.Post("/v1/sendEmails", handlers.SendEmails)
-	r.Get("/v3/accounts/{orgID}/users", handlers.AccountsV3UsersHandler)
-	r.Post("/v3/accounts/{orgID}/usersBy", handlers.AccountsV3UsersByHandler)
-	r.Get("/v1/auth", handlers.AuthV1Handler)
+	mux.HandleFunc("GET /{$}", handlers.Status)
+	mux.HandleFunc("GET /v1/jwt", handlers.JWTV1Handler)
+	mux.HandleFunc("POST /v1/users", handlers.UsersV1Handler)
+	mux.HandleFunc("POST /v1/sendEmails", handlers.SendEmails)
+	mux.HandleFunc("GET /v3/accounts/{orgID}/users", handlers.AccountsV3UsersHandler)
+	mux.HandleFunc("POST /v3/accounts/{orgID}/usersBy", handlers.AccountsV3UsersByHandler)
+	mux.HandleFunc("GET /v1/auth", handlers.AuthV1Handler)
 
 	// all the handlers that need xrhid
-	r.With(identity.EnforceIdentity).Group(func(r chi.Router) {
-		r.Get("/v1/registrations", handlers.RegistrationListHandler)
-		r.Post("/v1/registrations", handlers.RegistrationCreateHandler)
-		r.Delete("/v1/registrations/{uid}", handlers.RegistrationDeleteHandler)
-		r.Get("/v1/registrations/token", handlers.TokenHandler)
+	mux.HandleFunc("GET /v1/registrations", withIdentity(handlers.RegistrationListHandler))
+	mux.HandleFunc("POST /v1/registrations", withIdentity(handlers.RegistrationCreateHandler))
+	mux.HandleFunc("DELETE /v1/registrations/{uid}", withIdentity(handlers.RegistrationDeleteHandler))
+	mux.HandleFunc("GET /v1/registrations/token", withIdentity(handlers.TokenHandler))
 
-		r.Get("/api/mbop/v1/allowlist", handlers.AllowlistListHandler)
-		r.Post("/api/mbop/v1/allowlist", handlers.AllowlistCreateHandler)
-		r.Delete("/api/mbop/v1/allowlist", handlers.AllowlistDeleteHandler)
+	mux.HandleFunc("GET /api/mbop/v1/allowlist", withIdentity(handlers.AllowlistListHandler))
+	mux.HandleFunc("POST /api/mbop/v1/allowlist", withIdentity(handlers.AllowlistCreateHandler))
+	mux.HandleFunc("DELETE /api/mbop/v1/allowlist", withIdentity(handlers.AllowlistDeleteHandler))
+
+	// Catch-all handler for /v* and /api/entitlements*
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/v") || strings.HasPrefix(r.URL.Path, "/api/entitlements") {
+			handlers.CatchAll(w, r)
+			return
+		}
+		http.NotFound(w, r)
 	})
 
 	err := mailer.InitConfig()
@@ -68,11 +68,14 @@ func main() {
 	interrupts := make(chan os.Signal, 1)
 	signal.Notify(interrupts, os.Interrupt, syscall.SIGTERM)
 
+	// Wrap mux with logging middleware
+	handler := middleware.Logging(mux)
+
 	go func() {
 		srv := http.Server{
 			Addr:              ":" + conf.Port,
 			ReadHeaderTimeout: 2 * time.Second,
-			Handler:           r,
+			Handler:           handler,
 		}
 
 		l.Log.Info("Starting MBOP HTTP Listener", "port", conf.Port)
@@ -86,7 +89,7 @@ func main() {
 			srv := http.Server{
 				Addr:              ":" + conf.TLSPort,
 				ReadHeaderTimeout: 2 * time.Second,
-				Handler:           r,
+				Handler:           handler,
 			}
 
 			l.Log.Info("Starting MBOP HTTPS Listener", "port", conf.TLSPort)
@@ -97,4 +100,8 @@ func main() {
 	}
 
 	<-interrupts
+}
+
+func withIdentity(h http.HandlerFunc) http.HandlerFunc {
+	return identity.EnforceIdentity(h).ServeHTTP
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.31.0
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.4
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.51.0
-	github.com/go-chi/chi/v5 v5.2.2
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/zapr v1.3.0
 	github.com/golang-jwt/jwt/v5 v5.3.0

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,6 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/go-chi/chi v4.1.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
-github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
-github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
@@ -178,16 +176,12 @@ github.com/jackc/pgx/v4 v4.12.1-0.20210724153913-640aa07df17c/go.mod h1:1QD0+tgS
 github.com/jackc/pgx/v4 v4.18.2/go.mod h1:Ey4Oru5tH5sB6tV7hDmfWFahwF15Eb7DNXlRKx2CkVw=
 github.com/jackc/pgx/v4 v4.18.3 h1:dE2/TrEsGX3RBprb3qryqSV9Y60iZN1C6i8IrmW9/BA=
 github.com/jackc/pgx/v4 v4.18.3/go.mod h1:Ey4Oru5tH5sB6tV7hDmfWFahwF15Eb7DNXlRKx2CkVw=
-github.com/jackc/pgx/v5 v5.5.4 h1:Xp2aQS8uXButQdnCMWNmvx6UysWQQC+u1EoizjguY+8=
-github.com/jackc/pgx/v5 v5.5.4/go.mod h1:ez9gk+OAat140fv9ErkZDYFWmXLfV+++K0uAOiwgm1A=
 github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
 github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
-github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk=
-github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-chi/chi/v5"
 	l "github.com/redhatinsights/mbop/internal/logger"
 	"github.com/redhatinsights/mbop/internal/models"
 )
@@ -167,7 +166,7 @@ func getUsersByBody(r *http.Request) (models.UsersByBody, error) {
 }
 
 func getOrgIDFromPath(r *http.Request) string {
-	return chi.URLParam(r, "orgID")
+	return r.PathValue("orgID")
 }
 
 func getSortOrder(r *http.Request) (string, error) {

--- a/internal/handlers/helpers_test.go
+++ b/internal/handlers/helpers_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/redhatinsights/mbop/internal/config"
 )
 
@@ -25,8 +24,8 @@ func TestSendJSONWithStatusCodeContentTypeHeader(t *testing.T) {
 
 	config.Get().UsersModule = "mock"
 
-	testRouter := chi.NewRouter()
-	testRouter.Get("/v3/accounts/{orgID}/users", AccountsV3UsersHandler)
+	testRouter := http.NewServeMux()
+	testRouter.HandleFunc("GET /v3/accounts/{orgID}/users", AccountsV3UsersHandler)
 
 	testServer := httptest.NewServer(testRouter)
 	defer testServer.Close()

--- a/internal/handlers/registration_handler.go
+++ b/internal/handlers/registration_handler.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/redhatinsights/mbop/internal/config"
 	"github.com/redhatinsights/mbop/internal/store"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
@@ -155,7 +154,7 @@ func RegistrationCreateHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func RegistrationDeleteHandler(w http.ResponseWriter, r *http.Request) {
-	uid := chi.URLParam(r, "uid")
+	uid := r.PathValue("uid")
 	if uid == "" {
 		do400(w, "invalid uid passed in path")
 	}

--- a/internal/handlers/registration_handler_test.go
+++ b/internal/handlers/registration_handler_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/redhatinsights/mbop/internal/config"
 	"github.com/redhatinsights/mbop/internal/logger"
 	"github.com/redhatinsights/mbop/internal/store"
@@ -242,15 +241,12 @@ func (suite *RegistrationTestSuite) TestSuccessfulRegistrationDelete() {
 	_, err := suite.store.Create(&store.Registration{UID: "abc1234", OrgID: "1234"})
 	suite.Nil(err)
 
-	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("uid", "abc1234")
-
-	req := httptest.NewRequest(http.MethodDelete, "http://foobar/registrations/{uid}", nil)
+	req := httptest.NewRequest(http.MethodDelete, "http://foobar/registrations/abc1234", nil)
+	req.SetPathValue("uid", "abc1234")
 	req = req.WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{Identity: identity.Identity{
 		User:  identity.User{OrgAdmin: true, Username: "foobar"},
 		OrgID: "1234",
 	}}))
-	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 	req.Header.Set("x-rh-certauth-cn", "/CN=abc1234")
 
 	RegistrationDeleteHandler(suite.rec, req)
@@ -264,15 +260,12 @@ func (suite *RegistrationTestSuite) TestNotOrgAdminDelete() {
 	_, err := suite.store.Create(&store.Registration{UID: "abc1234", OrgID: "1234"})
 	suite.Nil(err)
 
-	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("uid", "abc1234")
-
-	req := httptest.NewRequest(http.MethodDelete, "http://foobar/registrations/{uid}", nil)
+	req := httptest.NewRequest(http.MethodDelete, "http://foobar/registrations/abc1234", nil)
+	req.SetPathValue("uid", "abc1234")
 	req = req.WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{Identity: identity.Identity{
 		User:  identity.User{OrgAdmin: false, Username: "foobar"},
 		OrgID: "1234",
 	}}))
-	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 	req.Header.Set("x-rh-certauth-cn", "/CN=abc1234")
 
 	RegistrationDeleteHandler(suite.rec, req)
@@ -283,15 +276,12 @@ func (suite *RegistrationTestSuite) TestNotOrgAdminDelete() {
 }
 
 func (suite *RegistrationTestSuite) TestRegistrationNotFoundDelete() {
-	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("uid", "abc1234")
-
-	req := httptest.NewRequest(http.MethodDelete, "http://foobar/registrations/{uid}", nil)
+	req := httptest.NewRequest(http.MethodDelete, "http://foobar/registrations/abc1234", nil)
+	req.SetPathValue("uid", "abc1234")
 	req = req.WithContext(context.WithValue(context.Background(), identity.Key, identity.XRHID{Identity: identity.Identity{
 		User:  identity.User{OrgAdmin: true, Username: "foobar"},
 		OrgID: "1234",
 	}}))
-	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 	req.Header.Set("x-rh-certauth-cn", "/CN=abc1234")
 
 	RegistrationDeleteHandler(suite.rec, req)


### PR DESCRIPTION
now that the go stdlib has method/parameter matching it doesn't hurt to just use the stdlib routing. 