### PR TITLE
[Bug Fix] fix not omitting userCount on empty search which causes 500 internal error.

### DIFF
--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -1,7 +1,7 @@
 package models
 
 type Users struct {
-	UserCount int    `json:"userCount,omitempty"`
+	UserCount int    `json:"userCount"`
 	Users     []User `json:"users,omitempty"`
 }
 


### PR DESCRIPTION
Summary

  Fixes a critical bug where searching for users with partial match criteria that return no results causes a 500 Internal Server Error in RBAC. The issue was caused by the omitempty JSON tag on the UserCount
  field, which omitted the field when its value was 0.

  Problem

  When users search for a username that doesn't exist in the ITless environment (e.g., searching for "sadsa" or "xyz123"), they receive a 500 Internal Server Error instead of an empty result set.

  Error flow:
  1. User searches with partial match criteria → no results found
  2. mbop sets UserCount = 0
  3. Go's JSON marshaler sees omitempty tag and omits the userCount field from JSON
  4. Response sent to RBAC: {"users": []} (missing userCount)
  5. RBAC tries to parse userCount → gets None
  6. RBAC calls int(None) for pagination calculations → TypeError
  7. User sees 500 error

  Why it worked with non-empty results:
  - When users are found: UserCount = 5 (non-zero)
  - JSON includes: {"userCount": 5, "users": [...]}
  - RBAC successfully parses userCount for pagination
  - No error occurs

  Solution

  Remove the omitempty JSON tag from the UserCount field in the Users struct. This ensures the field is always included in JSON responses, even when the value is 0.

  Changes

  File: internal/models/user.go

  Before:
  type Users struct {
      UserCount int    `json:"userCount,omitempty"`  // ❌ Omits field when 0
      Users     []User `json:"users,omitempty"`
  }

  After:
  type Users struct {
      UserCount int    `json:"userCount"`  // ✅ Always included
      Users     []User `json:"users,omitempty"`
  }

  Testing

  Verified JSON serialization behavior:

  Empty results (UserCount = 0):
  {
    "userCount": 0
  }
  ✅ Field is now present

  Non-empty results (UserCount = 2):
  {
    "userCount": 2,
    "users": [
      {"username": "alice"},
      {"username": "bob"}
    ]
  }
  ✅ Field still present as before