### PR TITLE
[Bug Fix] remove ommit empty from the users struct for return.

### DIFF
--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -2,7 +2,7 @@ package models
 
 type Users struct {
 	UserCount int    `json:"userCount"`
-	Users     []User `json:"users,omitempty"`
+	Users     []User `json:"users"`
 }
 
 type UserV3Responses struct {


### PR DESCRIPTION
  #### Problem

  Searching for users with partial match criteria that return no results causes a 500 Internal Server Error in RBAC. Users cannot search for non-existent usernames without encountering errors.

 ####  Root Cause

  The Users struct had omitempty JSON tags on both UserCount and Users fields. When a search returned no results:
  - UserCount = 0 → omitted from JSON (zero value)
  - Users = [] → omitted from JSON (empty slice)
  - mbop returned: {} (empty object)
  - RBAC expected: {"userCount": 0, "users": []}
  - RBAC tried to access missing fields → int(None) → TypeError → 500 error

  #### Solution

  Removed omitempty tags from both UserCount and Users fields in the Users struct to ensure both fields are always present in JSON responses, even when empty.